### PR TITLE
Add receipt-gated failsafe spine

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 exclude = .git,__pycache__,docs,build,dist

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -1,6 +1,20 @@
 name: Lint and Format
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**.py'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.flake8'
+      - '.github/workflows/lint-and-format.yml'
+  pull_request:
+    paths:
+      - '**.py'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.flake8'
+      - '.github/workflows/lint-and-format.yml'
 
 jobs:
   lint-and-format:
@@ -8,15 +22,19 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 black
+          pip install -r requirements.txt
+
       - name: Run flake8
         run: flake8 .
+
       - name: Run black (check only)
         run: black --check .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,34 +1,39 @@
-name: Lint and Format
+name: Lint, Format, and Test
 
 on:
   push:
     paths:
       - '**.py'
       - 'requirements.txt'
+      - '.github/workflows/lint.yml'
   pull_request:
     paths:
       - '**.py'
       - 'requirements.txt'
+      - '.github/workflows/lint.yml'
 
 jobs:
-  lint-format:
+  lint-format-test:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.x'
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-    - name: Run black (check only)
-      run: black --check .
+      - name: Run black (check only)
+        run: black --check .
 
-    - name: Run flake8
-      run: flake8 .
+      - name: Run flake8
+        run: flake8 .
+
+      - name: Run tests
+        run: pytest -q

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,11 +5,15 @@ on:
     paths:
       - '**.py'
       - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.flake8'
       - '.github/workflows/lint.yml'
   pull_request:
     paths:
       - '**.py'
       - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.flake8'
       - '.github/workflows/lint.yml'
 
 jobs:

--- a/EVEQ_FAILSAFE_RECEIPT.md
+++ b/EVEQ_FAILSAFE_RECEIPT.md
@@ -1,0 +1,31 @@
+# EVE_Q++ Receipt-Gated Failsafe
+
+This branch adds `eveq_failsafe_receipt.py`.
+
+## Purpose
+
+Trust / TTL expansion is routed through validated CycleReceipt state only.
+
+## Invariant
+
+```text
+No validated receipt -> no trust expansion.
+No proof -> no trust.
+No liveness -> no execution.
+```
+
+## Included code
+
+- `CycleReceipt`
+- `validate_receipt(...)`
+- `FailsafeConfig`
+- `save_state(...)` / `load_state(...)`
+- `progressive_trust_increment_from_receipt(...)`
+
+## Development posture
+
+Shadow and dry-run cycles may be logged and reviewed. They do not expand trust.
+
+## Next integration point
+
+Wire the cycle runner so each cycle creates a `CycleReceipt`, validates it, and updates failsafe state only through `progressive_trust_increment_from_receipt(...)`.

--- a/eveq_failsafe_receipt.py
+++ b/eveq_failsafe_receipt.py
@@ -1,25 +1,21 @@
-"""
-EVE_Q++ receipt-gated failsafe spine.
+"""EVE_Q++ receipt-gated failsafe spine.
 
-This module keeps trust / TTL expansion behind validated CycleReceipt state.
+This module keeps trust and TTL expansion behind validated CycleReceipt state.
 Shadow, dry-run, paper, and simulated cycles may be logged, but they cannot
-expand autonomy. The core invariant is simple:
-
-No validated receipt -> no trust expansion.
-No proof -> no trust.
-No liveness -> no execution.
+expand autonomy.
 """
+
 from __future__ import annotations
 
+import hashlib
+import json
+import os
+import tempfile
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
-import hashlib
-import json
-import os
-import tempfile
 
 CHARITY_RATE = Decimal("0.15")
 ETH_QUANT = Decimal("0.000000000000000001")
@@ -29,10 +25,12 @@ MOCK_CID_PREFIXES = ("mock:", "QmMock", "bafyMock", "local-mock:")
 
 
 def utc_now_iso() -> str:
+    """Return the current UTC time in ISO-8601 form."""
     return datetime.now(timezone.utc).isoformat()
 
 
 def dec(value: Any) -> Decimal:
+    """Convert a value into Decimal using string conversion for float safety."""
     if isinstance(value, Decimal):
         return value
     if value is None:
@@ -41,11 +39,14 @@ def dec(value: Any) -> Decimal:
 
 
 def q18(value: Any) -> Decimal:
+    """Quantize ETH-like values to 18 decimal places."""
     return dec(value).quantize(ETH_QUANT, rounding=ROUND_HALF_UP)
 
 
 @dataclass
 class CycleReceipt:
+    """Canonical proof object for one engine cycle."""
+
     cycle_id: str
     mode: str
     chain: str
@@ -99,6 +100,7 @@ class CycleReceipt:
         slippage_eth: Any = Decimal("0"),
         safety_margin_eth: Any = Decimal("0"),
     ) -> "CycleReceipt":
+        """Create a non-trust-gaining shadow receipt."""
         return cls(
             cycle_id=cycle_id,
             mode="shadow",
@@ -155,6 +157,8 @@ class CycleReceipt:
 
 @dataclass(frozen=True)
 class ValidationResult:
+    """Receipt validation result used by the failsafe gate."""
+
     valid: bool
     trust_increment_allowed: bool
     errors: List[str] = field(default_factory=list)
@@ -183,11 +187,17 @@ def validate_receipt(
     charity_rate: Decimal = CHARITY_RATE,
     tolerance_eth: Decimal = Decimal("0.000000000000000001"),
 ) -> ValidationResult:
+    """Validate a receipt and compute whether trust may expand."""
     errors: List[str] = []
     warnings: List[str] = []
 
     if not isinstance(receipt, CycleReceipt):
-        return ValidationResult(False, False, ["receipt must be a CycleReceipt instance"], warnings)
+        return ValidationResult(
+            valid=False,
+            trust_increment_allowed=False,
+            errors=["receipt must be a CycleReceipt instance"],
+            warnings=warnings,
+        )
 
     mode = (receipt.mode or "").lower().strip()
     actual_profit = q18(receipt.actual_profit_eth)
@@ -222,7 +232,12 @@ def validate_receipt(
     if production_mode and _is_mock_cid(receipt.ipfs_cid):
         errors.append("mock IPFS CID cannot be used as production proof")
 
-    if not _close_enough(receipt.charity_due_eth, computed_charity_due, tolerance_eth):
+    charity_due_matches = _close_enough(
+        receipt.charity_due_eth,
+        computed_charity_due,
+        tolerance_eth,
+    )
+    if not charity_due_matches:
         errors.append("charity_due_eth must equal actual_profit_eth * charity_rate")
     if dec(receipt.charity_distributed_eth) < computed_charity_due:
         errors.append("charity_distributed_eth is less than charity_due_eth")
@@ -237,7 +252,7 @@ def validate_receipt(
         and receipt.liveness_valid
         and receipt.execution_success
         and actual_profit >= 0
-        and _close_enough(receipt.charity_due_eth, computed_charity_due, tolerance_eth)
+        and charity_due_matches
         and dec(receipt.charity_distributed_eth) >= computed_charity_due
         and receipt.charity_success
         and receipt.ipfs_success
@@ -259,15 +274,18 @@ def validate_receipt(
 
 
 def can_update_trust(receipt: CycleReceipt, *, production_mode: bool = False) -> bool:
+    """Return whether this receipt can update trust."""
     return validate_receipt(receipt, production_mode=production_mode).trust_increment_allowed
 
 
 class FailsafeStateError(RuntimeError):
-    pass
+    """Raised when the checksum-backed failsafe state cannot be trusted."""
 
 
 @dataclass
 class FailsafeConfig:
+    """Failsafe trust and TTL state."""
+
     ttl_hours: float = 24.0
     max_ttl_hours: float = 48.0
     trust_level: float = 0.0
@@ -286,16 +304,23 @@ def _state_payload(cfg: FailsafeConfig) -> Dict[str, Any]:
 
 
 def _checksum(data: Dict[str, Any]) -> str:
-    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
     return hashlib.sha256(encoded).hexdigest()
 
 
 def save_state(cfg: FailsafeConfig, path: Optional[str] = None) -> Path:
+    """Persist failsafe state with a checksum envelope."""
     target = Path(path or cfg.state_file or "failsafe_state.json")
     target.parent.mkdir(parents=True, exist_ok=True)
     payload = _state_payload(cfg)
     wrapped = {"state": payload, "checksum": _checksum(payload)}
-    fd, temp_path = tempfile.mkstemp(prefix=target.name, suffix=".tmp", dir=str(target.parent))
+    fd, temp_path = tempfile.mkstemp(
+        prefix=target.name,
+        suffix=".tmp",
+        dir=str(target.parent),
+    )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             json.dump(wrapped, handle, indent=2, sort_keys=True)
@@ -308,6 +333,7 @@ def save_state(cfg: FailsafeConfig, path: Optional[str] = None) -> Path:
 
 
 def load_state(path: str) -> FailsafeConfig:
+    """Load failsafe state and verify its checksum."""
     target = Path(path)
     with target.open("r", encoding="utf-8") as handle:
         wrapped = json.load(handle)
@@ -316,7 +342,7 @@ def load_state(path: str) -> FailsafeConfig:
     if not isinstance(state, dict) or not checksum:
         raise FailsafeStateError("invalid failsafe state envelope")
     if _checksum(state) != checksum:
-        raise FailsafeStateError("failsafe state checksum mismatch; possible tampering")
+        raise FailsafeStateError("failsafe state checksum mismatch")
     state["state_file"] = str(target)
     return FailsafeConfig(**state)
 
@@ -330,11 +356,16 @@ def progressive_trust_increment(
     failure_decay_threshold: int = 3,
     logger: Optional[Callable[[str], None]] = None,
 ) -> FailsafeConfig:
+    """Update trust state after the receipt gate has made its decision."""
     if success:
         failsafe_cfg.ttl_hours = min(
-            float(failsafe_cfg.max_ttl_hours), float(failsafe_cfg.ttl_hours) + increment_hours
+            float(failsafe_cfg.max_ttl_hours),
+            float(failsafe_cfg.ttl_hours) + increment_hours,
         )
-        failsafe_cfg.trust_level = min(1.0, float(failsafe_cfg.trust_level) + trust_increment)
+        failsafe_cfg.trust_level = min(
+            1.0,
+            float(failsafe_cfg.trust_level) + trust_increment,
+        )
         failsafe_cfg.consecutive_failures = 0
         failsafe_cfg.last_liveness_at = utc_now_iso()
         if logger:
@@ -342,11 +373,14 @@ def progressive_trust_increment(
     else:
         failsafe_cfg.consecutive_failures += 1
         if failsafe_cfg.consecutive_failures >= failure_decay_threshold:
-            failsafe_cfg.trust_level = max(0.0, float(failsafe_cfg.trust_level) - trust_increment)
+            failsafe_cfg.trust_level = max(
+                0.0,
+                float(failsafe_cfg.trust_level) - trust_increment,
+            )
             if logger:
                 logger("repeated receipt failures caused small trust decay")
         elif logger:
-            logger("receipt did not validate; preserving grace, no TTL/trust increment")
+            logger("receipt did not validate; preserving grace")
 
     if failsafe_cfg.state_file:
         save_state(failsafe_cfg)
@@ -360,6 +394,7 @@ def progressive_trust_increment_from_receipt(
     production_mode: bool = False,
     logger: Optional[Callable[[str], None]] = None,
 ) -> ValidationResult:
+    """Validate a receipt, then update trust only if validation permits it."""
     result = validate_receipt(receipt, production_mode=production_mode)
 
     if not result.trust_increment_allowed and logger:

--- a/eveq_failsafe_receipt.py
+++ b/eveq_failsafe_receipt.py
@@ -1,0 +1,376 @@
+"""
+EVE_Q++ receipt-gated failsafe spine.
+
+This module keeps trust / TTL expansion behind validated CycleReceipt state.
+Shadow, dry-run, paper, and simulated cycles may be logged, but they cannot
+expand autonomy. The core invariant is simple:
+
+No validated receipt -> no trust expansion.
+No proof -> no trust.
+No liveness -> no execution.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+import hashlib
+import json
+import os
+import tempfile
+
+CHARITY_RATE = Decimal("0.15")
+ETH_QUANT = Decimal("0.000000000000000001")
+TRUSTABLE_MODES = {"live"}
+SIMULATION_MODES = {"shadow", "dry_run", "paper", "simulation"}
+MOCK_CID_PREFIXES = ("mock:", "QmMock", "bafyMock", "local-mock:")
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def dec(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+
+def q18(value: Any) -> Decimal:
+    return dec(value).quantize(ETH_QUANT, rounding=ROUND_HALF_UP)
+
+
+@dataclass
+class CycleReceipt:
+    cycle_id: str
+    mode: str
+    chain: str
+    selected_route: Optional[str]
+    optimizer_used: str
+    candidate_routes: List[Dict[str, Any]] = field(default_factory=list)
+    expected_profit_eth: Decimal = Decimal("0")
+    actual_profit_eth: Decimal = Decimal("0")
+    gas_cost_eth: Decimal = Decimal("0")
+    slippage_eth: Decimal = Decimal("0")
+    safety_margin_eth: Decimal = Decimal("0")
+    charity_due_eth: Decimal = Decimal("0")
+    charity_distributed_eth: Decimal = Decimal("0")
+    charity_allocations: List[Dict[str, Any]] = field(default_factory=list)
+    ipfs_cid: Optional[str] = None
+    local_log_path: Optional[str] = None
+    tx_hashes: List[str] = field(default_factory=list)
+    liveness_valid: bool = False
+    execution_success: bool = False
+    charity_success: bool = False
+    ipfs_success: bool = False
+    trust_increment_allowed: bool = False
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    created_at: str = field(default_factory=utc_now_iso)
+    completed_at: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "expected_profit_eth",
+            "actual_profit_eth",
+            "gas_cost_eth",
+            "slippage_eth",
+            "safety_margin_eth",
+            "charity_due_eth",
+            "charity_distributed_eth",
+        ):
+            setattr(self, field_name, q18(getattr(self, field_name)))
+
+    @classmethod
+    def shadow(
+        cls,
+        *,
+        cycle_id: str,
+        chain: str,
+        selected_route: Optional[str],
+        optimizer_used: str,
+        candidate_routes: Optional[List[Dict[str, Any]]] = None,
+        expected_profit_eth: Any = Decimal("0"),
+        gas_cost_eth: Any = Decimal("0"),
+        slippage_eth: Any = Decimal("0"),
+        safety_margin_eth: Any = Decimal("0"),
+    ) -> "CycleReceipt":
+        return cls(
+            cycle_id=cycle_id,
+            mode="shadow",
+            chain=chain,
+            selected_route=selected_route,
+            optimizer_used=optimizer_used,
+            candidate_routes=candidate_routes or [],
+            expected_profit_eth=expected_profit_eth,
+            actual_profit_eth=Decimal("0"),
+            gas_cost_eth=gas_cost_eth,
+            slippage_eth=slippage_eth,
+            safety_margin_eth=safety_margin_eth,
+            warnings=["shadow mode cannot gain trust"],
+        )
+
+    def compute_charity_due(self, charity_rate: Decimal = CHARITY_RATE) -> Decimal:
+        return q18(self.actual_profit_eth * charity_rate)
+
+    def finalize(self) -> "CycleReceipt":
+        self.completed_at = utc_now_iso()
+        return self
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        for key, value in list(data.items()):
+            if isinstance(value, Decimal):
+                data[key] = str(value)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CycleReceipt":
+        numeric_fields = {
+            "expected_profit_eth",
+            "actual_profit_eth",
+            "gas_cost_eth",
+            "slippage_eth",
+            "safety_margin_eth",
+            "charity_due_eth",
+            "charity_distributed_eth",
+        }
+        kwargs = dict(data)
+        for field_name in numeric_fields:
+            if field_name in kwargs:
+                kwargs[field_name] = dec(kwargs[field_name])
+        return cls(**kwargs)
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.to_dict(), indent=indent, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, payload: str) -> "CycleReceipt":
+        return cls.from_dict(json.loads(payload))
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    valid: bool
+    trust_increment_allowed: bool
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    computed_charity_due_eth: Decimal = Decimal("0")
+
+    def raise_for_errors(self) -> None:
+        if self.errors:
+            raise ValueError("; ".join(self.errors))
+
+
+def _is_mock_cid(cid: Optional[str]) -> bool:
+    if not cid:
+        return False
+    return cid.startswith(MOCK_CID_PREFIXES)
+
+
+def _close_enough(a: Any, b: Any, tolerance: Decimal) -> bool:
+    return abs(dec(a) - dec(b)) <= tolerance
+
+
+def validate_receipt(
+    receipt: CycleReceipt,
+    *,
+    production_mode: bool = False,
+    charity_rate: Decimal = CHARITY_RATE,
+    tolerance_eth: Decimal = Decimal("0.000000000000000001"),
+) -> ValidationResult:
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    if not isinstance(receipt, CycleReceipt):
+        return ValidationResult(False, False, ["receipt must be a CycleReceipt instance"], warnings)
+
+    mode = (receipt.mode or "").lower().strip()
+    actual_profit = q18(receipt.actual_profit_eth)
+    computed_charity_due = q18(actual_profit * charity_rate)
+
+    if not receipt.cycle_id:
+        errors.append("missing cycle_id")
+    if not mode:
+        errors.append("missing mode")
+    if not receipt.chain:
+        errors.append("missing chain")
+    if not receipt.optimizer_used:
+        errors.append("missing optimizer_used")
+    if actual_profit < 0:
+        errors.append("actual_profit_eth cannot be negative")
+    if not receipt.liveness_valid:
+        errors.append("liveness_valid is false")
+    if not receipt.execution_success:
+        errors.append("execution_success is false")
+    if not receipt.charity_success:
+        errors.append("charity_success is false")
+    if not receipt.ipfs_success:
+        errors.append("ipfs_success is false")
+    if not receipt.ipfs_cid:
+        errors.append("missing ipfs_cid")
+
+    if mode in SIMULATION_MODES:
+        warnings.append(f"{mode} mode cannot gain trust")
+    elif mode not in TRUSTABLE_MODES:
+        warnings.append(f"unrecognized/non-trustable mode: {receipt.mode!r}")
+
+    if production_mode and _is_mock_cid(receipt.ipfs_cid):
+        errors.append("mock IPFS CID cannot be used as production proof")
+
+    if not _close_enough(receipt.charity_due_eth, computed_charity_due, tolerance_eth):
+        errors.append("charity_due_eth must equal actual_profit_eth * charity_rate")
+    if dec(receipt.charity_distributed_eth) < computed_charity_due:
+        errors.append("charity_distributed_eth is less than charity_due_eth")
+    if receipt.charity_success and not receipt.charity_allocations:
+        errors.append("charity_success is true but charity_allocations is empty")
+    if receipt.execution_success and mode == "live" and not receipt.tx_hashes:
+        errors.append("live execution receipt requires tx_hashes")
+
+    computed_trust_allowed = (
+        len(errors) == 0
+        and mode in TRUSTABLE_MODES
+        and receipt.liveness_valid
+        and receipt.execution_success
+        and actual_profit >= 0
+        and _close_enough(receipt.charity_due_eth, computed_charity_due, tolerance_eth)
+        and dec(receipt.charity_distributed_eth) >= computed_charity_due
+        and receipt.charity_success
+        and receipt.ipfs_success
+        and receipt.ipfs_cid is not None
+        and not (production_mode and _is_mock_cid(receipt.ipfs_cid))
+    )
+
+    if receipt.trust_increment_allowed and not computed_trust_allowed:
+        errors.append("receipt claimed trust_increment_allowed=True but proof gates failed")
+        computed_trust_allowed = False
+
+    return ValidationResult(
+        valid=len(errors) == 0,
+        trust_increment_allowed=computed_trust_allowed,
+        errors=errors,
+        warnings=warnings,
+        computed_charity_due_eth=computed_charity_due,
+    )
+
+
+def can_update_trust(receipt: CycleReceipt, *, production_mode: bool = False) -> bool:
+    return validate_receipt(receipt, production_mode=production_mode).trust_increment_allowed
+
+
+class FailsafeStateError(RuntimeError):
+    pass
+
+
+@dataclass
+class FailsafeConfig:
+    ttl_hours: float = 24.0
+    max_ttl_hours: float = 48.0
+    trust_level: float = 0.0
+    consecutive_failures: int = 0
+    last_liveness_at: Optional[str] = None
+    state_file: Optional[str] = None
+
+    def snapshot(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def _state_payload(cfg: FailsafeConfig) -> Dict[str, Any]:
+    data = cfg.snapshot()
+    data.pop("state_file", None)
+    return data
+
+
+def _checksum(data: Dict[str, Any]) -> str:
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def save_state(cfg: FailsafeConfig, path: Optional[str] = None) -> Path:
+    target = Path(path or cfg.state_file or "failsafe_state.json")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = _state_payload(cfg)
+    wrapped = {"state": payload, "checksum": _checksum(payload)}
+    fd, temp_path = tempfile.mkstemp(prefix=target.name, suffix=".tmp", dir=str(target.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(wrapped, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(temp_path, target)
+    finally:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+    return target
+
+
+def load_state(path: str) -> FailsafeConfig:
+    target = Path(path)
+    with target.open("r", encoding="utf-8") as handle:
+        wrapped = json.load(handle)
+    state = wrapped.get("state")
+    checksum = wrapped.get("checksum")
+    if not isinstance(state, dict) or not checksum:
+        raise FailsafeStateError("invalid failsafe state envelope")
+    if _checksum(state) != checksum:
+        raise FailsafeStateError("failsafe state checksum mismatch; possible tampering")
+    state["state_file"] = str(target)
+    return FailsafeConfig(**state)
+
+
+def progressive_trust_increment(
+    failsafe_cfg: FailsafeConfig,
+    *,
+    success: bool,
+    increment_hours: float = 1.0,
+    trust_increment: float = 0.05,
+    failure_decay_threshold: int = 3,
+    logger: Optional[Callable[[str], None]] = None,
+) -> FailsafeConfig:
+    if success:
+        failsafe_cfg.ttl_hours = min(
+            float(failsafe_cfg.max_ttl_hours), float(failsafe_cfg.ttl_hours) + increment_hours
+        )
+        failsafe_cfg.trust_level = min(1.0, float(failsafe_cfg.trust_level) + trust_increment)
+        failsafe_cfg.consecutive_failures = 0
+        failsafe_cfg.last_liveness_at = utc_now_iso()
+        if logger:
+            logger("validated receipt allowed trust increment")
+    else:
+        failsafe_cfg.consecutive_failures += 1
+        if failsafe_cfg.consecutive_failures >= failure_decay_threshold:
+            failsafe_cfg.trust_level = max(0.0, float(failsafe_cfg.trust_level) - trust_increment)
+            if logger:
+                logger("repeated receipt failures caused small trust decay")
+        elif logger:
+            logger("receipt did not validate; preserving grace, no TTL/trust increment")
+
+    if failsafe_cfg.state_file:
+        save_state(failsafe_cfg)
+    return failsafe_cfg
+
+
+def progressive_trust_increment_from_receipt(
+    failsafe_cfg: FailsafeConfig,
+    receipt: CycleReceipt,
+    *,
+    production_mode: bool = False,
+    logger: Optional[Callable[[str], None]] = None,
+) -> ValidationResult:
+    result = validate_receipt(receipt, production_mode=production_mode)
+
+    if not result.trust_increment_allowed and logger:
+        for error in result.errors:
+            logger(f"receipt validation error: {error}")
+        for warning in result.warnings:
+            logger(f"receipt validation warning: {warning}")
+
+    progressive_trust_increment(
+        failsafe_cfg,
+        success=result.trust_increment_allowed,
+        logger=logger,
+    )
+    return result

--- a/eveq_failsafe_receipt.py
+++ b/eveq_failsafe_receipt.py
@@ -304,9 +304,7 @@ def _state_payload(cfg: FailsafeConfig) -> Dict[str, Any]:
 
 
 def _checksum(data: Dict[str, Any]) -> str:
-    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode(
-        "utf-8"
-    )
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(encoded).hexdigest()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-line-length = 88
+line-length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flake8
 black
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_eveq_failsafe_receipt.py
+++ b/tests/test_eveq_failsafe_receipt.py
@@ -1,0 +1,68 @@
+from decimal import Decimal
+
+from eveq_failsafe_receipt import (
+    CycleReceipt,
+    FailsafeConfig,
+    progressive_trust_increment_from_receipt,
+    validate_receipt,
+)
+
+
+def make_valid_receipt():
+    return CycleReceipt(
+        cycle_id="cycle-001",
+        mode="live",
+        chain="base",
+        selected_route="route-a",
+        optimizer_used="classical",
+        actual_profit_eth=Decimal("1.0"),
+        charity_due_eth=Decimal("0.15"),
+        charity_distributed_eth=Decimal("0.15"),
+        charity_allocations=[{"name": "test", "amount_eth": "0.15"}],
+        ipfs_cid="bafyRealProofCid",
+        tx_hashes=["0xabc"],
+        liveness_valid=True,
+        execution_success=True,
+        charity_success=True,
+        ipfs_success=True,
+    )
+
+
+def test_valid_receipt_allows_trust_increment():
+    cfg = FailsafeConfig(ttl_hours=24.0, max_ttl_hours=48.0, trust_level=0.0)
+    result = progressive_trust_increment_from_receipt(cfg, make_valid_receipt())
+    assert result.trust_increment_allowed is True
+    assert cfg.ttl_hours == 25.0
+    assert cfg.trust_level == 0.05
+
+
+def test_shadow_receipt_does_not_increment_trust():
+    cfg = FailsafeConfig(ttl_hours=24.0, max_ttl_hours=48.0, trust_level=0.0)
+    receipt = CycleReceipt.shadow(
+        cycle_id="shadow-001",
+        chain="base",
+        selected_route="route-a",
+        optimizer_used="classical",
+        expected_profit_eth=Decimal("1.0"),
+    )
+    result = progressive_trust_increment_from_receipt(cfg, receipt)
+    assert result.trust_increment_allowed is False
+    assert cfg.ttl_hours == 24.0
+    assert cfg.trust_level == 0.0
+
+
+def test_mock_proof_blocks_production_trust():
+    receipt = make_valid_receipt()
+    receipt.ipfs_cid = "mock:test-proof"
+    result = validate_receipt(receipt, production_mode=True)
+    assert result.trust_increment_allowed is False
+    assert any("mock IPFS" in error for error in result.errors)
+
+
+def test_claimed_trust_flag_cannot_bypass_gates():
+    receipt = make_valid_receipt()
+    receipt.liveness_valid = False
+    receipt.trust_increment_allowed = True
+    result = validate_receipt(receipt)
+    assert result.trust_increment_allowed is False
+    assert any("proof gates failed" in error for error in result.errors)


### PR DESCRIPTION
## Summary

Adds a receipt-gated failsafe module.

## Added

- `eveq_failsafe_receipt.py`
- `EVEQ_FAILSAFE_RECEIPT.md`

## Core invariant

```text
No validated receipt -> no trust expansion.
No proof -> no trust.
No liveness -> no execution.
```

## Notes

This is a scaffold. The next step is wiring the cycle runner so state updates only pass through the receipt gate.