### PR TITLE
Add shadow cycle runner

### DIFF
--- a/shadow_cycle_runner.py
+++ b/shadow_cycle_runner.py
@@ -1,0 +1,149 @@
+"""Shadow cycle runner for EVE_Q++ receipt pipeline exercises.
+
+The runner simulates one complete observation cycle without moving capital. It
+emits a shadow-mode CycleReceipt, validates it, writes a receipt JSON file, and
+confirms that shadow cycles can learn/log without expanding trust.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from eveq_failsafe_receipt import (
+    CycleReceipt,
+    FailsafeConfig,
+    ValidationResult,
+    progressive_trust_increment_from_receipt,
+    q18,
+)
+
+
+@dataclass(frozen=True)
+class ShadowCycleRun:
+    """Result bundle for a simulated shadow cycle."""
+
+    receipt: CycleReceipt
+    validation: ValidationResult
+    receipt_path: Path
+    failsafe: FailsafeConfig
+
+
+def score_candidate_route(candidate: Dict[str, Any]) -> Dict[str, Any]:
+    """Score a candidate route using profit minus gas, slippage, and margin."""
+    expected_profit = Decimal(str(candidate.get("expected_profit_eth", "0")))
+    gas_cost = Decimal(str(candidate.get("gas_cost_eth", "0")))
+    slippage = Decimal(str(candidate.get("slippage_eth", "0")))
+    safety_margin = Decimal(str(candidate.get("safety_margin_eth", "0")))
+    score = q18(expected_profit - gas_cost - slippage - safety_margin)
+    scored = dict(candidate)
+    scored["score_eth"] = score
+    return scored
+
+
+def default_candidate_routes() -> List[Dict[str, Any]]:
+    """Return deterministic mock candidate routes for shadow-mode testing."""
+    return [
+        {
+            "route": "mock-base-weth-usdc-weth",
+            "chain": "base",
+            "expected_profit_eth": Decimal("0.020000000000000000"),
+            "gas_cost_eth": Decimal("0.005000000000000000"),
+            "slippage_eth": Decimal("0.001000000000000000"),
+            "safety_margin_eth": Decimal("0.002000000000000000"),
+        },
+        {
+            "route": "mock-base-weth-dai-weth",
+            "chain": "base",
+            "expected_profit_eth": Decimal("0.012000000000000000"),
+            "gas_cost_eth": Decimal("0.004500000000000000"),
+            "slippage_eth": Decimal("0.001500000000000000"),
+            "safety_margin_eth": Decimal("0.002000000000000000"),
+        },
+    ]
+
+
+def build_shadow_receipt(
+    *,
+    cycle_id: Optional[str] = None,
+    candidate_routes: Optional[List[Dict[str, Any]]] = None,
+) -> CycleReceipt:
+    """Build a fully populated shadow CycleReceipt from mock route data."""
+    routes = [score_candidate_route(route) for route in candidate_routes or default_candidate_routes()]
+    selected = max(routes, key=lambda route: route["score_eth"])
+    actual_profit = q18(selected["score_eth"])
+
+    receipt = CycleReceipt.shadow(
+        cycle_id=cycle_id or f"shadow-{uuid4().hex}",
+        chain=str(selected["chain"]),
+        selected_route=str(selected["route"]),
+        optimizer_used="shadow-score-v0",
+        candidate_routes=routes,
+        expected_profit_eth=selected["expected_profit_eth"],
+        gas_cost_eth=selected["gas_cost_eth"],
+        slippage_eth=selected["slippage_eth"],
+        safety_margin_eth=selected["safety_margin_eth"],
+    )
+
+    receipt.actual_profit_eth = actual_profit
+    receipt.charity_due_eth = receipt.compute_charity_due()
+    receipt.charity_distributed_eth = receipt.charity_due_eth
+    receipt.charity_allocations = [
+        {
+            "recipient": "mock-charity-ledger",
+            "amount_eth": receipt.charity_due_eth,
+            "proof_type": "shadow-local-only",
+        }
+    ]
+    receipt.ipfs_cid = f"mock:{receipt.cycle_id}"
+    receipt.local_log_path = None
+    receipt.tx_hashes = []
+    receipt.liveness_valid = True
+    receipt.execution_success = True
+    receipt.charity_success = True
+    receipt.ipfs_success = True
+    receipt.trust_increment_allowed = False
+    return receipt.finalize()
+
+
+def write_receipt(receipt: CycleReceipt, output_dir: Path) -> Path:
+    """Write a receipt JSON document and return the resulting path."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    receipt_path = output_dir / f"{receipt.cycle_id}.json"
+    receipt.local_log_path = str(receipt_path)
+    receipt_path.write_text(receipt.to_json(indent=2), encoding="utf-8")
+    return receipt_path
+
+
+def run_shadow_cycle(
+    *,
+    output_dir: Path | str = "receipts",
+    failsafe: Optional[FailsafeConfig] = None,
+    cycle_id: Optional[str] = None,
+    candidate_routes: Optional[List[Dict[str, Any]]] = None,
+) -> ShadowCycleRun:
+    """Run one simulated shadow cycle through the receipt validation gate."""
+    failsafe_cfg = failsafe or FailsafeConfig()
+    receipt = build_shadow_receipt(cycle_id=cycle_id, candidate_routes=candidate_routes)
+    validation = progressive_trust_increment_from_receipt(
+        failsafe_cfg,
+        receipt,
+        production_mode=False,
+    )
+    receipt_path = write_receipt(receipt, Path(output_dir))
+    return ShadowCycleRun(
+        receipt=receipt,
+        validation=validation,
+        receipt_path=receipt_path,
+        failsafe=failsafe_cfg,
+    )
+
+
+if __name__ == "__main__":
+    run = run_shadow_cycle()
+    print(f"Receipt path: {run.receipt_path}")
+    print(f"Receipt valid: {run.validation.valid}")
+    print(f"Trust increment allowed: {run.validation.trust_increment_allowed}")

--- a/shadow_cycle_runner.py
+++ b/shadow_cycle_runner.py
@@ -72,7 +72,8 @@ def build_shadow_receipt(
     candidate_routes: Optional[List[Dict[str, Any]]] = None,
 ) -> CycleReceipt:
     """Build a fully populated shadow CycleReceipt from mock route data."""
-    routes = [score_candidate_route(route) for route in candidate_routes or default_candidate_routes()]
+    source_routes = candidate_routes or default_candidate_routes()
+    routes = [score_candidate_route(route) for route in source_routes]
     selected = max(routes, key=lambda route: route["score_eth"])
     actual_profit = q18(selected["score_eth"])
 
@@ -127,7 +128,10 @@ def run_shadow_cycle(
 ) -> ShadowCycleRun:
     """Run one simulated shadow cycle through the receipt validation gate."""
     failsafe_cfg = failsafe or FailsafeConfig()
-    receipt = build_shadow_receipt(cycle_id=cycle_id, candidate_routes=candidate_routes)
+    receipt = build_shadow_receipt(
+        cycle_id=cycle_id,
+        candidate_routes=candidate_routes,
+    )
     validation = progressive_trust_increment_from_receipt(
         failsafe_cfg,
         receipt,

--- a/tests/test_shadow_cycle_runner.py
+++ b/tests/test_shadow_cycle_runner.py
@@ -1,0 +1,54 @@
+import json
+from decimal import Decimal
+
+from eveq_failsafe_receipt import FailsafeConfig
+from shadow_cycle_runner import build_shadow_receipt, run_shadow_cycle, score_candidate_route
+
+
+def test_score_candidate_route_subtracts_costs_and_margin():
+    route = {
+        "expected_profit_eth": Decimal("0.020000000000000000"),
+        "gas_cost_eth": Decimal("0.005000000000000000"),
+        "slippage_eth": Decimal("0.001000000000000000"),
+        "safety_margin_eth": Decimal("0.002000000000000000"),
+    }
+
+    scored = score_candidate_route(route)
+
+    assert scored["score_eth"] == Decimal("0.012000000000000000")
+
+
+def test_build_shadow_receipt_is_valid_but_not_trustable():
+    receipt = build_shadow_receipt(cycle_id="shadow-test-cycle")
+
+    assert receipt.mode == "shadow"
+    assert receipt.liveness_valid is True
+    assert receipt.execution_success is True
+    assert receipt.charity_success is True
+    assert receipt.ipfs_success is True
+    assert receipt.ipfs_cid == "mock:shadow-test-cycle"
+    assert receipt.trust_increment_allowed is False
+
+
+def test_run_shadow_cycle_writes_receipt_and_blocks_trust(tmp_path):
+    failsafe = FailsafeConfig(ttl_hours=24.0, max_ttl_hours=48.0, trust_level=0.0)
+
+    run = run_shadow_cycle(
+        output_dir=tmp_path,
+        failsafe=failsafe,
+        cycle_id="shadow-test-cycle",
+    )
+
+    assert run.validation.valid is True
+    assert run.validation.trust_increment_allowed is False
+    assert any("shadow mode cannot gain trust" in item for item in run.validation.warnings)
+    assert run.failsafe.ttl_hours == 24.0
+    assert run.failsafe.trust_level == 0.0
+    assert run.failsafe.consecutive_failures == 1
+    assert run.receipt_path.exists()
+
+    payload = json.loads(run.receipt_path.read_text(encoding="utf-8"))
+    assert payload["cycle_id"] == "shadow-test-cycle"
+    assert payload["mode"] == "shadow"
+    assert payload["candidate_routes"][0]["score_eth"] == "0.012000000000000000"
+    assert payload["charity_allocations"][0]["amount_eth"] == "0.001800000000000000"

--- a/tests/test_shadow_cycle_runner.py
+++ b/tests/test_shadow_cycle_runner.py
@@ -2,7 +2,11 @@ import json
 from decimal import Decimal
 
 from eveq_failsafe_receipt import FailsafeConfig
-from shadow_cycle_runner import build_shadow_receipt, run_shadow_cycle, score_candidate_route
+from shadow_cycle_runner import (
+    build_shadow_receipt,
+    run_shadow_cycle,
+    score_candidate_route,
+)
 
 
 def test_score_candidate_route_subtracts_costs_and_margin():


### PR DESCRIPTION
## Summary

Adds a shadow-mode runner that exercises the EVE_Q++ receipt pipeline end-to-end without moving capital or expanding trust.

## Changes

- Adds `shadow_cycle_runner.py`
  - scores deterministic mock candidate routes
  - emits a shadow-mode `CycleReceipt`
  - validates through `progressive_trust_increment_from_receipt(...)`
  - writes a local receipt JSON file
- Adds tests for:
  - route scoring
  - populated shadow receipt construction
  - receipt writing
  - validation success with trust increment denied

## Safety posture

No wallet logic, no RPC calls, no execution path, no live capital movement. Shadow cycles may log and learn, but cannot expand trust.