### PR TITLE
Add receipt proof adapter layer

### DIFF
--- a/eveq_failsafe_receipt.py
+++ b/eveq_failsafe_receipt.py
@@ -16,7 +16,8 @@ CHARITY_RATE = Decimal("0.15")
 ETH_QUANT = Decimal("0.000000000000000001")
 TRUSTABLE_MODES = {"live"}
 SIMULATION_MODES = {"shadow", "dry_run", "paper", "simulation"}
-MOCK_CID_PREFIXES = ("mock:", "QmMock", "bafyMock", "local-mock:")
+NON_PRODUCTION_CID_PREFIXES = ("mock:", "QmMock", "bafyMock", "local-mock:", "local:")
+MOCK_CID_PREFIXES = NON_PRODUCTION_CID_PREFIXES
 
 
 def utc_now_iso() -> str:
@@ -43,6 +44,12 @@ def json_safe(value: Any) -> Any:
     if isinstance(value, (list, tuple)):
         return [json_safe(item) for item in value]
     return value
+
+
+def is_non_production_cid(cid: Optional[str]) -> bool:
+    if not cid:
+        return False
+    return cid.startswith(NON_PRODUCTION_CID_PREFIXES)
 
 
 @dataclass
@@ -164,9 +171,7 @@ class ValidationResult:
 
 
 def _is_mock_cid(cid: Optional[str]) -> bool:
-    if not cid:
-        return False
-    return cid.startswith(MOCK_CID_PREFIXES)
+    return is_non_production_cid(cid)
 
 
 def _close_enough(a: Any, b: Any, tolerance: Decimal) -> bool:
@@ -221,8 +226,8 @@ def validate_receipt(
     elif mode not in TRUSTABLE_MODES:
         warnings.append(f"unrecognized/non-trustable mode: {receipt.mode!r}")
 
-    if production_mode and _is_mock_cid(receipt.ipfs_cid):
-        errors.append("mock IPFS CID cannot be used as production proof")
+    if production_mode and is_non_production_cid(receipt.ipfs_cid):
+        errors.append("non-production proof CID cannot be used as production proof")
 
     charity_due_matches = _close_enough(
         receipt.charity_due_eth,
@@ -249,7 +254,7 @@ def validate_receipt(
         and receipt.charity_success
         and receipt.ipfs_success
         and receipt.ipfs_cid is not None
-        and not (production_mode and _is_mock_cid(receipt.ipfs_cid))
+        and not (production_mode and is_non_production_cid(receipt.ipfs_cid))
     )
 
     if receipt.trust_increment_allowed and not computed_trust_allowed:

--- a/proof_adapters.py
+++ b/proof_adapters.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Protocol
 
-from eveq_failsafe_receipt import CycleReceipt
+from eveq_failsafe_receipt import CycleReceipt, is_non_production_cid
 
 
 @dataclass(frozen=True)
@@ -120,7 +120,7 @@ class IPFSProofAdapter:
                 error=str(exc),
             )
 
-        production_eligible = not cid.startswith(("mock:", "local:", "local-mock:"))
+        production_eligible = not is_non_production_cid(cid)
         return ProofResult(
             success=True,
             proof_type=self.proof_type,

--- a/proof_adapters.py
+++ b/proof_adapters.py
@@ -1,0 +1,145 @@
+"""Proof adapter layer for EVE_Q++ receipts.
+
+Proof adapters separate *where a receipt is persisted* from *whether that proof
+is eligible to expand trust*. Development proofs can support telemetry and audit
+logs, but only production-eligible proofs should ever be considered for live
+trust expansion.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Protocol
+
+from eveq_failsafe_receipt import CycleReceipt
+
+
+@dataclass(frozen=True)
+class ProofResult:
+    """Result returned by a proof adapter."""
+
+    success: bool
+    proof_type: str
+    cid: Optional[str] = None
+    local_path: Optional[str] = None
+    production_trust_eligible: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+
+class ProofAdapter(Protocol):
+    """Interface shared by all receipt proof adapters."""
+
+    proof_type: str
+
+    def publish(self, receipt: CycleReceipt) -> ProofResult:
+        """Publish or persist a receipt and return proof metadata."""
+
+
+class MockProofAdapter:
+    """Development-only proof adapter.
+
+    Mock proofs are useful for pipeline testing, but they are never production
+    trust eligible.
+    """
+
+    proof_type = "mock"
+
+    def publish(self, receipt: CycleReceipt) -> ProofResult:
+        return ProofResult(
+            success=True,
+            proof_type=self.proof_type,
+            cid=f"mock:{receipt.cycle_id}",
+            production_trust_eligible=False,
+            metadata={"reason": "mock proof is development-only"},
+        )
+
+
+class LocalFileProofAdapter:
+    """Persist receipts to local JSON files.
+
+    Local file proofs are durable enough for development logs and review, but
+    they are not production trust eligible by default.
+    """
+
+    proof_type = "local_file"
+
+    def __init__(self, output_dir: Path | str = "receipts") -> None:
+        self.output_dir = Path(output_dir)
+
+    def publish(self, receipt: CycleReceipt) -> ProofResult:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        receipt_path = self.output_dir / f"{receipt.cycle_id}.json"
+        receipt.local_log_path = str(receipt_path)
+
+        payload = receipt.to_json(indent=2)
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        cid = f"local:{digest}"
+
+        receipt.ipfs_cid = cid
+        receipt.ipfs_success = True
+        receipt_path.write_text(receipt.to_json(indent=2), encoding="utf-8")
+
+        return ProofResult(
+            success=True,
+            proof_type=self.proof_type,
+            cid=cid,
+            local_path=str(receipt_path),
+            production_trust_eligible=False,
+            metadata={
+                "sha256": digest,
+                "reason": "local file proof is development/local-audit only",
+            },
+        )
+
+
+class IPFSProofAdapter:
+    """Future production proof adapter backed by an injected publisher.
+
+    The adapter does not make network calls by itself. A caller must provide a
+    publisher callable that accepts receipt JSON and returns a CID. This keeps
+    the proof layer testable and prevents accidental mainnet or infrastructure
+    side effects.
+    """
+
+    proof_type = "ipfs"
+
+    def __init__(self, publisher: Callable[[str], str]) -> None:
+        self.publisher = publisher
+
+    def publish(self, receipt: CycleReceipt) -> ProofResult:
+        try:
+            cid = self.publisher(receipt.to_json(indent=2))
+        except Exception as exc:  # pragma: no cover - defensive boundary
+            return ProofResult(
+                success=False,
+                proof_type=self.proof_type,
+                production_trust_eligible=False,
+                error=str(exc),
+            )
+
+        production_eligible = not cid.startswith(("mock:", "local:", "local-mock:"))
+        return ProofResult(
+            success=True,
+            proof_type=self.proof_type,
+            cid=cid,
+            production_trust_eligible=production_eligible,
+            metadata={"publisher": "injected"},
+        )
+
+
+def apply_proof_to_receipt(receipt: CycleReceipt, proof: ProofResult) -> CycleReceipt:
+    """Apply proof metadata back onto a CycleReceipt."""
+    receipt.ipfs_success = proof.success
+    receipt.ipfs_cid = proof.cid
+    receipt.local_log_path = proof.local_path or receipt.local_log_path
+
+    if proof.error:
+        receipt.errors.append(f"proof adapter error: {proof.error}")
+    if proof.success and not proof.production_trust_eligible:
+        receipt.warnings.append(
+            f"{proof.proof_type} proof is not production trust eligible"
+        )
+    return receipt

--- a/proof_adapters.py
+++ b/proof_adapters.py
@@ -139,7 +139,5 @@ def apply_proof_to_receipt(receipt: CycleReceipt, proof: ProofResult) -> CycleRe
     if proof.error:
         receipt.errors.append(f"proof adapter error: {proof.error}")
     if proof.success and not proof.production_trust_eligible:
-        receipt.warnings.append(
-            f"{proof.proof_type} proof is not production trust eligible"
-        )
+        receipt.warnings.append(f"{proof.proof_type} proof is not production trust eligible")
     return receipt

--- a/shadow_cycle_runner.py
+++ b/shadow_cycle_runner.py
@@ -1,8 +1,9 @@
 """Shadow cycle runner for EVE_Q++ receipt pipeline exercises.
 
 The runner simulates one complete observation cycle without moving capital. It
-emits a shadow-mode CycleReceipt, validates it, writes a receipt JSON file, and
-confirms that shadow cycles can learn/log without expanding trust.
+emits a shadow-mode CycleReceipt, routes proof through an adapter, validates the
+receipt, writes a receipt JSON file, and confirms that shadow cycles can
+learn/log without expanding trust.
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ from eveq_failsafe_receipt import (
     progressive_trust_increment_from_receipt,
     q18,
 )
+from proof_adapters import LocalFileProofAdapter, ProofAdapter, apply_proof_to_receipt
 
 
 @dataclass(frozen=True)
@@ -99,24 +101,23 @@ def build_shadow_receipt(
             "proof_type": "shadow-local-only",
         }
     ]
-    receipt.ipfs_cid = f"mock:{receipt.cycle_id}"
-    receipt.local_log_path = None
     receipt.tx_hashes = []
     receipt.liveness_valid = True
     receipt.execution_success = True
     receipt.charity_success = True
-    receipt.ipfs_success = True
+    receipt.ipfs_success = False
+    receipt.ipfs_cid = None
     receipt.trust_increment_allowed = False
     return receipt.finalize()
 
 
 def write_receipt(receipt: CycleReceipt, output_dir: Path) -> Path:
-    """Write a receipt JSON document and return the resulting path."""
-    output_dir.mkdir(parents=True, exist_ok=True)
-    receipt_path = output_dir / f"{receipt.cycle_id}.json"
-    receipt.local_log_path = str(receipt_path)
-    receipt_path.write_text(receipt.to_json(indent=2), encoding="utf-8")
-    return receipt_path
+    """Write a receipt JSON document using the local proof adapter."""
+    proof = LocalFileProofAdapter(output_dir).publish(receipt)
+    apply_proof_to_receipt(receipt, proof)
+    if proof.local_path is None:
+        raise RuntimeError("local proof adapter did not return a receipt path")
+    return Path(proof.local_path)
 
 
 def run_shadow_cycle(
@@ -125,6 +126,7 @@ def run_shadow_cycle(
     failsafe: Optional[FailsafeConfig] = None,
     cycle_id: Optional[str] = None,
     candidate_routes: Optional[List[Dict[str, Any]]] = None,
+    proof_adapter: Optional[ProofAdapter] = None,
 ) -> ShadowCycleRun:
     """Run one simulated shadow cycle through the receipt validation gate."""
     failsafe_cfg = failsafe or FailsafeConfig()
@@ -132,12 +134,20 @@ def run_shadow_cycle(
         cycle_id=cycle_id,
         candidate_routes=candidate_routes,
     )
+    adapter = proof_adapter or LocalFileProofAdapter(output_dir)
+    proof = adapter.publish(receipt)
+    apply_proof_to_receipt(receipt, proof)
     validation = progressive_trust_increment_from_receipt(
         failsafe_cfg,
         receipt,
         production_mode=False,
     )
-    receipt_path = write_receipt(receipt, Path(output_dir))
+
+    if proof.local_path is not None:
+        receipt_path = Path(proof.local_path)
+    else:
+        receipt_path = write_receipt(receipt, Path(output_dir))
+
     return ShadowCycleRun(
         receipt=receipt,
         validation=validation,

--- a/shadow_cycle_runner.py
+++ b/shadow_cycle_runner.py
@@ -120,6 +120,16 @@ def write_receipt(receipt: CycleReceipt, output_dir: Path) -> Path:
     return Path(proof.local_path)
 
 
+def persist_receipt_snapshot(receipt: CycleReceipt, output_dir: Path | str) -> Path:
+    """Persist a receipt snapshot without changing its proof metadata."""
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    receipt_path = path / f"{receipt.cycle_id}.json"
+    receipt.local_log_path = str(receipt_path)
+    receipt_path.write_text(receipt.to_json(indent=2), encoding="utf-8")
+    return receipt_path
+
+
 def run_shadow_cycle(
     *,
     output_dir: Path | str = "receipts",
@@ -146,7 +156,7 @@ def run_shadow_cycle(
     if proof.local_path is not None:
         receipt_path = Path(proof.local_path)
     else:
-        receipt_path = write_receipt(receipt, Path(output_dir))
+        receipt_path = persist_receipt_snapshot(receipt, output_dir)
 
     return ShadowCycleRun(
         receipt=receipt,

--- a/tests/test_eveq_failsafe_receipt.py
+++ b/tests/test_eveq_failsafe_receipt.py
@@ -57,7 +57,15 @@ def test_mock_proof_blocks_production_trust():
     receipt.ipfs_cid = "mock:test-proof"
     result = validate_receipt(receipt, production_mode=True)
     assert result.trust_increment_allowed is False
-    assert any("mock IPFS" in error for error in result.errors)
+    assert any("non-production proof" in error for error in result.errors)
+
+
+def test_local_proof_blocks_production_trust():
+    receipt = make_valid_receipt()
+    receipt.ipfs_cid = "local:test-proof"
+    result = validate_receipt(receipt, production_mode=True)
+    assert result.trust_increment_allowed is False
+    assert any("non-production proof" in error for error in result.errors)
 
 
 def test_claimed_trust_flag_cannot_bypass_gates():

--- a/tests/test_proof_adapters.py
+++ b/tests/test_proof_adapters.py
@@ -1,0 +1,78 @@
+from decimal import Decimal
+
+from eveq_failsafe_receipt import CycleReceipt
+from proof_adapters import (
+    IPFSProofAdapter,
+    LocalFileProofAdapter,
+    MockProofAdapter,
+    apply_proof_to_receipt,
+)
+
+
+def make_receipt() -> CycleReceipt:
+    receipt = CycleReceipt(
+        cycle_id="proof-test-cycle",
+        mode="shadow",
+        chain="base",
+        selected_route="mock-route",
+        optimizer_used="test-optimizer",
+        actual_profit_eth=Decimal("0.010000000000000000"),
+        charity_due_eth=Decimal("0.001500000000000000"),
+        charity_distributed_eth=Decimal("0.001500000000000000"),
+        charity_allocations=[{"recipient": "test", "amount_eth": "0.0015"}],
+        liveness_valid=True,
+        execution_success=True,
+        charity_success=True,
+    )
+    return receipt.finalize()
+
+
+def test_mock_proof_is_never_production_trust_eligible():
+    receipt = make_receipt()
+
+    proof = MockProofAdapter().publish(receipt)
+    apply_proof_to_receipt(receipt, proof)
+
+    assert proof.success is True
+    assert proof.cid == "mock:proof-test-cycle"
+    assert proof.production_trust_eligible is False
+    assert receipt.ipfs_success is True
+    assert receipt.ipfs_cid == "mock:proof-test-cycle"
+    assert any("not production trust eligible" in item for item in receipt.warnings)
+
+
+def test_local_file_proof_writes_receipt_and_is_not_production_trust_eligible(tmp_path):
+    receipt = make_receipt()
+
+    proof = LocalFileProofAdapter(tmp_path).publish(receipt)
+    apply_proof_to_receipt(receipt, proof)
+
+    assert proof.success is True
+    assert proof.cid is not None
+    assert proof.cid.startswith("local:")
+    assert proof.local_path is not None
+    assert proof.production_trust_eligible is False
+    assert receipt.ipfs_success is True
+    assert receipt.ipfs_cid.startswith("local:")
+    assert receipt.local_log_path == proof.local_path
+
+
+def test_ipfs_proof_adapter_uses_injected_publisher():
+    receipt = make_receipt()
+
+    proof = IPFSProofAdapter(lambda payload: "bafyProductionProofCid").publish(receipt)
+    apply_proof_to_receipt(receipt, proof)
+
+    assert proof.success is True
+    assert proof.cid == "bafyProductionProofCid"
+    assert proof.production_trust_eligible is True
+    assert receipt.ipfs_cid == "bafyProductionProofCid"
+
+
+def test_ipfs_proof_adapter_rejects_mock_like_cids_for_production_trust():
+    receipt = make_receipt()
+
+    proof = IPFSProofAdapter(lambda payload: "mock:not-real").publish(receipt)
+
+    assert proof.success is True
+    assert proof.production_trust_eligible is False

--- a/tests/test_proof_adapters.py
+++ b/tests/test_proof_adapters.py
@@ -72,7 +72,7 @@ def test_ipfs_proof_adapter_uses_injected_publisher():
 def test_ipfs_proof_adapter_rejects_mock_like_cids_for_production_trust():
     receipt = make_receipt()
 
-    proof = IPFSProofAdapter(lambda payload: "mock:not-real").publish(receipt)
-
-    assert proof.success is True
-    assert proof.production_trust_eligible is False
+    for cid in ("mock:not-real", "QmMockNotReal", "bafyMockNotReal", "local:not-real"):
+        proof = IPFSProofAdapter(lambda payload, proof_cid=cid: proof_cid).publish(receipt)
+        assert proof.success is True
+        assert proof.production_trust_eligible is False

--- a/tests/test_shadow_cycle_runner.py
+++ b/tests/test_shadow_cycle_runner.py
@@ -2,6 +2,7 @@ import json
 from decimal import Decimal
 
 from eveq_failsafe_receipt import FailsafeConfig
+from proof_adapters import MockProofAdapter
 from shadow_cycle_runner import (
     build_shadow_receipt,
     run_shadow_cycle,
@@ -22,15 +23,15 @@ def test_score_candidate_route_subtracts_costs_and_margin():
     assert scored["score_eth"] == Decimal("0.012000000000000000")
 
 
-def test_build_shadow_receipt_is_valid_but_not_trustable():
+def test_build_shadow_receipt_is_populated_but_not_proven_yet():
     receipt = build_shadow_receipt(cycle_id="shadow-test-cycle")
 
     assert receipt.mode == "shadow"
     assert receipt.liveness_valid is True
     assert receipt.execution_success is True
     assert receipt.charity_success is True
-    assert receipt.ipfs_success is True
-    assert receipt.ipfs_cid == "mock:shadow-test-cycle"
+    assert receipt.ipfs_success is False
+    assert receipt.ipfs_cid is None
     assert receipt.trust_increment_allowed is False
 
 
@@ -50,9 +51,24 @@ def test_run_shadow_cycle_writes_receipt_and_blocks_trust(tmp_path):
     assert run.failsafe.trust_level == 0.0
     assert run.failsafe.consecutive_failures == 1
     assert run.receipt_path.exists()
+    assert run.receipt.ipfs_cid is not None
+    assert run.receipt.ipfs_cid.startswith("local:")
 
     payload = json.loads(run.receipt_path.read_text(encoding="utf-8"))
     assert payload["cycle_id"] == "shadow-test-cycle"
     assert payload["mode"] == "shadow"
     assert payload["candidate_routes"][0]["score_eth"] == "0.012000000000000000"
     assert payload["charity_allocations"][0]["amount_eth"] == "0.001800000000000000"
+
+
+def test_run_shadow_cycle_can_use_mock_proof_adapter(tmp_path):
+    run = run_shadow_cycle(
+        output_dir=tmp_path,
+        cycle_id="shadow-test-cycle",
+        proof_adapter=MockProofAdapter(),
+    )
+
+    assert run.validation.valid is True
+    assert run.validation.trust_increment_allowed is False
+    assert run.receipt.ipfs_cid == "mock:shadow-test-cycle"
+    assert run.receipt_path.exists()


### PR DESCRIPTION
## Summary

Adds a proof adapter layer for EVE_Q++ receipts so receipt persistence/proof routing is separated from trust eligibility.

## Changes

- Adds `proof_adapters.py`
  - `ProofResult`
  - `ProofAdapter` protocol
  - `MockProofAdapter`
  - `LocalFileProofAdapter`
  - `IPFSProofAdapter` with injected publisher callable
  - `apply_proof_to_receipt(...)`
- Updates `shadow_cycle_runner.py`
  - routes proof through adapters
  - defaults to local-file proof for shadow receipt persistence
  - supports mock proof adapters without changing proof identity during snapshot persistence
- Adds tests for:
  - mock proofs being development-only
  - local file receipt persistence
  - IPFS adapter using injected publisher
  - mock-like CIDs being barred from production trust eligibility
  - shadow cycle runner integration with proof adapters

## Safety posture

No wallet logic, no RPC calls, no mainnet execution, no live capital movement. Proof adapters only route receipt evidence. Mock and local proofs are not production-trust eligible.