### PR TITLE
Add proof eligibility envelope

### DIFF
--- a/eveq_failsafe_receipt.py
+++ b/eveq_failsafe_receipt.py
@@ -68,6 +68,10 @@ class CycleReceipt:
     charity_due_eth: Decimal = Decimal("0")
     charity_distributed_eth: Decimal = Decimal("0")
     charity_allocations: List[Dict[str, Any]] = field(default_factory=list)
+    proof_type: Optional[str] = None
+    proof_production_trust_eligible: bool = False
+    proof_metadata: Dict[str, Any] = field(default_factory=dict)
+    proof_error: Optional[str] = None
     ipfs_cid: Optional[str] = None
     local_log_path: Optional[str] = None
     tx_hashes: List[str] = field(default_factory=list)
@@ -220,14 +224,21 @@ def validate_receipt(
         errors.append("ipfs_success is false")
     if not receipt.ipfs_cid:
         errors.append("missing ipfs_cid")
+    if receipt.proof_error:
+        errors.append(f"proof error: {receipt.proof_error}")
 
     if mode in SIMULATION_MODES:
         warnings.append(f"{mode} mode cannot gain trust")
     elif mode not in TRUSTABLE_MODES:
         warnings.append(f"unrecognized/non-trustable mode: {receipt.mode!r}")
 
-    if production_mode and is_non_production_cid(receipt.ipfs_cid):
-        errors.append("non-production proof CID cannot be used as production proof")
+    if production_mode:
+        if not receipt.proof_type:
+            errors.append("production proof requires proof_type")
+        if not receipt.proof_production_trust_eligible:
+            errors.append("production proof is not trust eligible")
+        if is_non_production_cid(receipt.ipfs_cid):
+            errors.append("non-production proof CID cannot be used as production proof")
 
     charity_due_matches = _close_enough(
         receipt.charity_due_eth,
@@ -243,6 +254,14 @@ def validate_receipt(
     if receipt.execution_success and mode == "live" and not receipt.tx_hashes:
         errors.append("live execution receipt requires tx_hashes")
 
+    production_proof_allowed = (
+        not production_mode
+        or (
+            receipt.proof_type is not None
+            and receipt.proof_production_trust_eligible
+            and not is_non_production_cid(receipt.ipfs_cid)
+        )
+    )
     computed_trust_allowed = (
         len(errors) == 0
         and mode in TRUSTABLE_MODES
@@ -254,7 +273,7 @@ def validate_receipt(
         and receipt.charity_success
         and receipt.ipfs_success
         and receipt.ipfs_cid is not None
-        and not (production_mode and is_non_production_cid(receipt.ipfs_cid))
+        and production_proof_allowed
     )
 
     if receipt.trust_increment_allowed and not computed_trust_allowed:

--- a/eveq_failsafe_receipt.py
+++ b/eveq_failsafe_receipt.py
@@ -254,13 +254,10 @@ def validate_receipt(
     if receipt.execution_success and mode == "live" and not receipt.tx_hashes:
         errors.append("live execution receipt requires tx_hashes")
 
-    production_proof_allowed = (
-        not production_mode
-        or (
-            receipt.proof_type is not None
-            and receipt.proof_production_trust_eligible
-            and not is_non_production_cid(receipt.ipfs_cid)
-        )
+    production_proof_allowed = not production_mode or (
+        receipt.proof_type is not None
+        and receipt.proof_production_trust_eligible
+        and not is_non_production_cid(receipt.ipfs_cid)
     )
     computed_trust_allowed = (
         len(errors) == 0

--- a/proof_adapters.py
+++ b/proof_adapters.py
@@ -102,7 +102,11 @@ def apply_proof_to_receipt(receipt: CycleReceipt, proof: ProofResult) -> CycleRe
     receipt.local_log_path = proof.local_path or receipt.local_log_path
     receipt.proof_type = proof.proof_type
     receipt.proof_production_trust_eligible = proof.production_trust_eligible
-    receipt.proof_metadata = {**proof.metadata, "cid": proof.cid, "local_path": proof.local_path}
+    receipt.proof_metadata = {
+        **proof.metadata,
+        "cid": proof.cid,
+        "local_path": proof.local_path,
+    }
     receipt.proof_error = proof.error
     if proof.error:
         receipt.errors.append(f"proof error: {proof.error}")

--- a/proof_adapters.py
+++ b/proof_adapters.py
@@ -1,11 +1,3 @@
-"""Proof adapter layer for EVE_Q++ receipts.
-
-Proof adapters separate *where a receipt is persisted* from *whether that proof
-is eligible to expand trust*. Development proofs can support telemetry and audit
-logs, but only production-eligible proofs should ever be considered for live
-trust expansion.
-"""
-
 from __future__ import annotations
 
 import hashlib
@@ -18,8 +10,6 @@ from eveq_failsafe_receipt import CycleReceipt, is_non_production_cid
 
 @dataclass(frozen=True)
 class ProofResult:
-    """Result returned by a proof adapter."""
-
     success: bool
     proof_type: str
     cid: Optional[str] = None
@@ -30,21 +20,13 @@ class ProofResult:
 
 
 class ProofAdapter(Protocol):
-    """Interface shared by all receipt proof adapters."""
-
     proof_type: str
 
     def publish(self, receipt: CycleReceipt) -> ProofResult:
-        """Publish or persist a receipt and return proof metadata."""
+        pass
 
 
 class MockProofAdapter:
-    """Development-only proof adapter.
-
-    Mock proofs are useful for pipeline testing, but they are never production
-    trust eligible.
-    """
-
     proof_type = "mock"
 
     def publish(self, receipt: CycleReceipt) -> ProofResult:
@@ -54,20 +36,11 @@ class MockProofAdapter:
             proof_type=self.proof_type,
             cid=cid,
             production_trust_eligible=False,
-            metadata={
-                "cid": cid,
-                "reason": "mock proof is development-only",
-            },
+            metadata={"cid": cid, "reason": "mock proof is development-only"},
         )
 
 
 class LocalFileProofAdapter:
-    """Persist receipts to local JSON files.
-
-    Local file proofs are durable enough for development logs and review, but
-    they are not production trust eligible by default.
-    """
-
     proof_type = "local_file"
 
     def __init__(self, output_dir: Path | str = "receipts") -> None:
@@ -77,15 +50,12 @@ class LocalFileProofAdapter:
         self.output_dir.mkdir(parents=True, exist_ok=True)
         receipt_path = self.output_dir / f"{receipt.cycle_id}.json"
         receipt.local_log_path = str(receipt_path)
-
         payload = receipt.to_json(indent=2)
         digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
         cid = f"local:{digest}"
-
         receipt.ipfs_cid = cid
         receipt.ipfs_success = True
         receipt_path.write_text(receipt.to_json(indent=2), encoding="utf-8")
-
         return ProofResult(
             success=True,
             proof_type=self.proof_type,
@@ -102,14 +72,6 @@ class LocalFileProofAdapter:
 
 
 class IPFSProofAdapter:
-    """Future production proof adapter backed by an injected publisher.
-
-    The adapter does not make network calls by itself. A caller must provide a
-    publisher callable that accepts receipt JSON and returns a CID. This keeps
-    the proof layer testable and prevents accidental mainnet or infrastructure
-    side effects.
-    """
-
     proof_type = "ipfs"
 
     def __init__(self, publisher: Callable[[str], str]) -> None:
@@ -118,45 +80,32 @@ class IPFSProofAdapter:
     def publish(self, receipt: CycleReceipt) -> ProofResult:
         try:
             cid = self.publisher(receipt.to_json(indent=2))
-        except Exception as exc:  # pragma: no cover - defensive boundary
+        except Exception as exc:  # pragma: no cover
             return ProofResult(
                 success=False,
                 proof_type=self.proof_type,
                 production_trust_eligible=False,
                 error=str(exc),
             )
-
-        production_eligible = not is_non_production_cid(cid)
         return ProofResult(
             success=True,
             proof_type=self.proof_type,
             cid=cid,
-            production_trust_eligible=production_eligible,
-            metadata={
-                "cid": cid,
-                "publisher": "injected",
-            },
+            production_trust_eligible=not is_non_production_cid(cid),
+            metadata={"cid": cid, "publisher": "injected"},
         )
 
 
 def apply_proof_to_receipt(receipt: CycleReceipt, proof: ProofResult) -> CycleReceipt:
-    """Apply proof metadata back onto a CycleReceipt."""
     receipt.ipfs_success = proof.success
     receipt.ipfs_cid = proof.cid
     receipt.local_log_path = proof.local_path or receipt.local_log_path
     receipt.proof_type = proof.proof_type
     receipt.proof_production_trust_eligible = proof.production_trust_eligible
-    receipt.proof_metadata = {
-        **proof.metadata,
-        "cid": proof.cid,
-        "local_path": proof.local_path,
-    }
+    receipt.proof_metadata = {**proof.metadata, "cid": proof.cid, "local_path": proof.local_path}
     receipt.proof_error = proof.error
-
     if proof.error:
-        receipt.errors.append(f"proof adapter error: {proof.error}")
+        receipt.errors.append(f"proof error: {proof.error}")
     if proof.success and not proof.production_trust_eligible:
-        receipt.warnings.append(
-            f"{proof.proof_type} proof is not production trust eligible"
-        )
+        receipt.warnings.append(f"{proof.proof_type} proof is not production trust eligible")
     return receipt

--- a/proof_adapters.py
+++ b/proof_adapters.py
@@ -156,5 +156,7 @@ def apply_proof_to_receipt(receipt: CycleReceipt, proof: ProofResult) -> CycleRe
     if proof.error:
         receipt.errors.append(f"proof adapter error: {proof.error}")
     if proof.success and not proof.production_trust_eligible:
-        receipt.warnings.append(f"{proof.proof_type} proof is not production trust eligible")
+        receipt.warnings.append(
+            f"{proof.proof_type} proof is not production trust eligible"
+        )
     return receipt

--- a/proof_adapters.py
+++ b/proof_adapters.py
@@ -48,12 +48,16 @@ class MockProofAdapter:
     proof_type = "mock"
 
     def publish(self, receipt: CycleReceipt) -> ProofResult:
+        cid = f"mock:{receipt.cycle_id}"
         return ProofResult(
             success=True,
             proof_type=self.proof_type,
-            cid=f"mock:{receipt.cycle_id}",
+            cid=cid,
             production_trust_eligible=False,
-            metadata={"reason": "mock proof is development-only"},
+            metadata={
+                "cid": cid,
+                "reason": "mock proof is development-only",
+            },
         )
 
 
@@ -89,6 +93,8 @@ class LocalFileProofAdapter:
             local_path=str(receipt_path),
             production_trust_eligible=False,
             metadata={
+                "cid": cid,
+                "local_path": str(receipt_path),
                 "sha256": digest,
                 "reason": "local file proof is development/local-audit only",
             },
@@ -126,7 +132,10 @@ class IPFSProofAdapter:
             proof_type=self.proof_type,
             cid=cid,
             production_trust_eligible=production_eligible,
-            metadata={"publisher": "injected"},
+            metadata={
+                "cid": cid,
+                "publisher": "injected",
+            },
         )
 
 
@@ -135,6 +144,14 @@ def apply_proof_to_receipt(receipt: CycleReceipt, proof: ProofResult) -> CycleRe
     receipt.ipfs_success = proof.success
     receipt.ipfs_cid = proof.cid
     receipt.local_log_path = proof.local_path or receipt.local_log_path
+    receipt.proof_type = proof.proof_type
+    receipt.proof_production_trust_eligible = proof.production_trust_eligible
+    receipt.proof_metadata = {
+        **proof.metadata,
+        "cid": proof.cid,
+        "local_path": proof.local_path,
+    }
+    receipt.proof_error = proof.error
 
     if proof.error:
         receipt.errors.append(f"proof adapter error: {proof.error}")

--- a/shadow_cycle_runner.py
+++ b/shadow_cycle_runner.py
@@ -117,7 +117,9 @@ def write_receipt(receipt: CycleReceipt, output_dir: Path) -> Path:
     apply_proof_to_receipt(receipt, proof)
     if proof.local_path is None:
         raise RuntimeError("local proof adapter did not return a receipt path")
-    return Path(proof.local_path)
+    receipt_path = Path(proof.local_path)
+    receipt_path.write_text(receipt.to_json(indent=2), encoding="utf-8")
+    return receipt_path
 
 
 def persist_receipt_snapshot(receipt: CycleReceipt, output_dir: Path | str) -> Path:
@@ -155,6 +157,7 @@ def run_shadow_cycle(
 
     if proof.local_path is not None:
         receipt_path = Path(proof.local_path)
+        receipt_path.write_text(receipt.to_json(indent=2), encoding="utf-8")
     else:
         receipt_path = persist_receipt_snapshot(receipt, output_dir)
 

--- a/tests/test_eveq_failsafe_receipt.py
+++ b/tests/test_eveq_failsafe_receipt.py
@@ -29,12 +29,32 @@ def make_valid_receipt():
     )
 
 
+def make_production_proven_receipt():
+    receipt = make_valid_receipt()
+    receipt.proof_type = "ipfs"
+    receipt.proof_production_trust_eligible = True
+    receipt.proof_metadata = {"cid": receipt.ipfs_cid, "publisher": "test"}
+    return receipt
+
+
 def test_valid_receipt_allows_trust_increment():
     cfg = FailsafeConfig(ttl_hours=24.0, max_ttl_hours=48.0, trust_level=0.0)
     result = progressive_trust_increment_from_receipt(cfg, make_valid_receipt())
     assert result.trust_increment_allowed is True
     assert cfg.ttl_hours == 25.0
     assert cfg.trust_level == 0.05
+
+
+def test_production_receipt_requires_eligible_proof_envelope():
+    result = validate_receipt(make_valid_receipt(), production_mode=True)
+    assert result.trust_increment_allowed is False
+    assert "production proof requires proof_type" in result.errors
+    assert "production proof is not trust eligible" in result.errors
+
+
+def test_production_receipt_with_eligible_proof_can_increment_trust():
+    result = validate_receipt(make_production_proven_receipt(), production_mode=True)
+    assert result.trust_increment_allowed is True
 
 
 def test_shadow_receipt_does_not_increment_trust():
@@ -53,7 +73,7 @@ def test_shadow_receipt_does_not_increment_trust():
 
 
 def test_mock_proof_blocks_production_trust():
-    receipt = make_valid_receipt()
+    receipt = make_production_proven_receipt()
     receipt.ipfs_cid = "mock:test-proof"
     result = validate_receipt(receipt, production_mode=True)
     assert result.trust_increment_allowed is False
@@ -61,7 +81,7 @@ def test_mock_proof_blocks_production_trust():
 
 
 def test_local_proof_blocks_production_trust():
-    receipt = make_valid_receipt()
+    receipt = make_production_proven_receipt()
     receipt.ipfs_cid = "local:test-proof"
     result = validate_receipt(receipt, production_mode=True)
     assert result.trust_increment_allowed is False

--- a/tests/test_proof_adapters.py
+++ b/tests/test_proof_adapters.py
@@ -38,6 +38,10 @@ def test_mock_proof_is_never_production_trust_eligible():
     assert proof.production_trust_eligible is False
     assert receipt.ipfs_success is True
     assert receipt.ipfs_cid == "mock:proof-test-cycle"
+    assert receipt.proof_type == "mock"
+    assert receipt.proof_production_trust_eligible is False
+    assert receipt.proof_metadata["cid"] == "mock:proof-test-cycle"
+    assert receipt.proof_error is None
     assert any("not production trust eligible" in item for item in receipt.warnings)
 
 
@@ -55,6 +59,9 @@ def test_local_file_proof_writes_receipt_and_is_not_production_trust_eligible(tm
     assert receipt.ipfs_success is True
     assert receipt.ipfs_cid.startswith("local:")
     assert receipt.local_log_path == proof.local_path
+    assert receipt.proof_type == "local_file"
+    assert receipt.proof_production_trust_eligible is False
+    assert receipt.proof_metadata["local_path"] == proof.local_path
 
 
 def test_ipfs_proof_adapter_uses_injected_publisher():
@@ -67,6 +74,9 @@ def test_ipfs_proof_adapter_uses_injected_publisher():
     assert proof.cid == "bafyProductionProofCid"
     assert proof.production_trust_eligible is True
     assert receipt.ipfs_cid == "bafyProductionProofCid"
+    assert receipt.proof_type == "ipfs"
+    assert receipt.proof_production_trust_eligible is True
+    assert receipt.proof_metadata["cid"] == "bafyProductionProofCid"
 
 
 def test_ipfs_proof_adapter_rejects_mock_like_cids_for_production_trust():

--- a/tests/test_shadow_cycle_runner.py
+++ b/tests/test_shadow_cycle_runner.py
@@ -32,6 +32,8 @@ def test_build_shadow_receipt_is_populated_but_not_proven_yet():
     assert receipt.charity_success is True
     assert receipt.ipfs_success is False
     assert receipt.ipfs_cid is None
+    assert receipt.proof_type is None
+    assert receipt.proof_production_trust_eligible is False
     assert receipt.trust_increment_allowed is False
 
 
@@ -53,10 +55,15 @@ def test_run_shadow_cycle_writes_receipt_and_blocks_trust(tmp_path):
     assert run.receipt_path.exists()
     assert run.receipt.ipfs_cid is not None
     assert run.receipt.ipfs_cid.startswith("local:")
+    assert run.receipt.proof_type == "local_file"
+    assert run.receipt.proof_production_trust_eligible is False
 
     payload = json.loads(run.receipt_path.read_text(encoding="utf-8"))
     assert payload["cycle_id"] == "shadow-test-cycle"
     assert payload["mode"] == "shadow"
+    assert payload["proof_type"] == "local_file"
+    assert payload["proof_production_trust_eligible"] is False
+    assert payload["proof_metadata"]["cid"].startswith("local:")
     assert payload["candidate_routes"][0]["score_eth"] == "0.012000000000000000"
     assert payload["charity_allocations"][0]["amount_eth"] == "0.001800000000000000"
 
@@ -71,4 +78,6 @@ def test_run_shadow_cycle_can_use_mock_proof_adapter(tmp_path):
     assert run.validation.valid is True
     assert run.validation.trust_increment_allowed is False
     assert run.receipt.ipfs_cid == "mock:shadow-test-cycle"
+    assert run.receipt.proof_type == "mock"
+    assert run.receipt.proof_production_trust_eligible is False
     assert run.receipt_path.exists()


### PR DESCRIPTION
## Summary

Adds an explicit proof eligibility envelope to `CycleReceipt` so adapter truth is carried into receipt truth before validation.

## Changes

- Adds receipt fields:
  - `proof_type`
  - `proof_production_trust_eligible`
  - `proof_metadata`
  - `proof_error`
- Updates production validation so `production_mode=True` requires:
  - proof type
  - proof marked production-trust eligible
  - non-mock/non-local CID
- Updates `apply_proof_to_receipt(...)` to copy proof metadata into the receipt envelope.
- Rewrites local shadow receipts after applying proof so persisted JSON includes proof envelope fields.
- Adds tests for:
  - production proof envelope requirement
  - production-eligible IPFS proof allowance
  - local/mock proof rejection
  - proof metadata copied onto receipts
  - proof envelope persistence in shadow runner receipts

## Safety posture

No wallet logic, no RPC calls, no mainnet execution, no live capital movement. This is trust-gate hardening only: adapter evidence must be explicit on the receipt before production trust can expand.