### PR TITLE
Add EVE_Q and Omega package scaffold

### DIFF
--- a/config/omega.example.yaml
+++ b/config/omega.example.yaml
@@ -1,0 +1,26 @@
+log_level: INFO
+
+database_path: data/omega_telemetry.sqlite
+health_path: logs/omega_health.json
+health_interval_seconds: 30
+
+observers:
+  - name: base_context
+    enabled: true
+    poll_interval_seconds: 60
+
+sentiment:
+  enabled: false
+  rules_path: rules/market_signal_rules.json
+  cooldown_minutes: 10
+  poll_interval_seconds: 60
+  min_score: 3.0
+  spike_window_minutes: 15
+  spike_threshold_count: 5
+  sources: []
+
+alerts:
+  telegram:
+    enabled: false
+  discord:
+    enabled: false

--- a/docs/omega_notes.md
+++ b/docs/omega_notes.md
@@ -1,0 +1,22 @@
+# Omega Notes
+
+Omega is the passive context layer for this branch.
+
+It records context signals into a local event store and writes a small health file.
+
+Primary files:
+
+- omega_telemetry/config_tools.py
+- omega_telemetry/models.py
+- omega_telemetry/db.py
+- omega_telemetry/health.py
+- omega_telemetry/signal_observer.py
+- omega_telemetry/context_runner.py
+- rules/market_signal_rules.json
+- config/omega.example.yaml
+
+Run command:
+
+```bash
+python -m omega_telemetry.context_runner --config config/omega.example.yaml
+```

--- a/eve_q/allocation/__init__.py
+++ b/eve_q/allocation/__init__.py
@@ -1,0 +1,1 @@
+"""Charity allocation recommendation package."""

--- a/eve_q/allocation/charity_router.py
+++ b/eve_q/allocation/charity_router.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+from eve_q.allocation.geodesic_policy import GeodesicInput, score_allocation
+
+
+def propose_allocations(signals: Iterable[GeodesicInput]) -> List[Dict[str, Any]]:
+    decisions = [score_allocation(signal).to_dict() for signal in signals]
+    total = sum(d["recommended_weight"] for d in decisions)
+    for decision in decisions:
+        decision["normalized_recommended_weight"] = (
+            decision["recommended_weight"] / total if total > 0 else 0.0
+        )
+    return sorted(decisions, key=lambda d: d["allocation_priority"], reverse=True)

--- a/eve_q/allocation/geodesic_policy.py
+++ b/eve_q/allocation/geodesic_policy.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List
+
+
+@dataclass(slots=True)
+class GeodesicInput:
+    charity_id: str
+    impact_score: float
+    need_score: float
+    urgency_score: float = 0.0
+    neglect_factor: float = 0.0
+    funding_gap_score: float = 0.0
+    absorptive_capacity_score: float = 0.0
+    confidence_score: float = 0.0
+    telemetry_source_reliability: float = 0.0
+    provenance: List[str] | None = None
+
+
+@dataclass(slots=True)
+class GeodesicDecision:
+    charity_id: str
+    allocation_priority: float
+    recommended_weight: float
+    requires_human_review: bool
+    hold_transfer: bool
+    reason_codes: List[str]
+    risk_flags: List[str]
+    inputs: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def score_allocation(signal: GeodesicInput) -> GeodesicDecision:
+    provenance = signal.provenance or []
+    impact = clamp01(signal.impact_score)
+    need = clamp01(signal.need_score)
+    urgency = clamp01(signal.urgency_score)
+    neglect = clamp01(signal.neglect_factor)
+    funding_gap = clamp01(signal.funding_gap_score)
+    absorb = clamp01(signal.absorptive_capacity_score)
+    confidence = clamp01(signal.confidence_score)
+    reliability = clamp01(signal.telemetry_source_reliability)
+
+    raw_priority = (
+        0.35 * impact
+        + 0.25 * need
+        + 0.15 * urgency
+        + 0.10 * neglect
+        + 0.10 * funding_gap
+        + 0.05 * absorb
+    )
+    allocation_priority = clamp01(raw_priority * confidence)
+
+    reason_codes: List[str] = []
+    risk_flags: List[str] = []
+    requires_review = False
+
+    if not provenance:
+        risk_flags.append("missing_provenance")
+        reason_codes.append("hold_without_provenance")
+        requires_review = True
+    if confidence < 0.55:
+        risk_flags.append("low_confidence")
+        requires_review = True
+    if reliability < 0.50:
+        risk_flags.append("low_source_reliability")
+        requires_review = True
+    if need >= 0.80 and impact < 0.35:
+        reason_codes.append("urgent_need_low_impact_review")
+        requires_review = True
+    if absorb < 0.25 and allocation_priority > 0.0:
+        risk_flags.append("limited_absorptive_capacity")
+        requires_review = True
+    if not reason_codes:
+        reason_codes.append("balanced_need_impact_signal")
+
+    return GeodesicDecision(
+        charity_id=signal.charity_id,
+        allocation_priority=allocation_priority,
+        recommended_weight=allocation_priority,
+        requires_human_review=requires_review,
+        hold_transfer=True,
+        reason_codes=reason_codes,
+        risk_flags=risk_flags,
+        inputs={
+            "impact_score": impact,
+            "need_score": need,
+            "urgency_score": urgency,
+            "neglect_factor": neglect,
+            "funding_gap_score": funding_gap,
+            "absorptive_capacity_score": absorb,
+            "confidence_score": confidence,
+            "telemetry_source_reliability": reliability,
+            "provenance": provenance,
+        },
+    )

--- a/eve_q/gates/__init__.py
+++ b/eve_q/gates/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime phase gates for the EVE_Q simulation scaffold."""

--- a/eve_q/gates/eve_phase.py
+++ b/eve_q/gates/eve_phase.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class EvePhase(str, Enum):
+    SIMULATION = "simulation"
+    TESTNET = "testnet"
+    SANDBOX = "sandbox"
+    CONSTRAINED_MAINNET = "constrained_mainnet"
+
+
+@dataclass(slots=True)
+class PhaseDecision:
+    phase: EvePhase
+    allowed_to_simulate: bool
+    allowed_to_run_testnet: bool
+    allowed_to_run_constrained_live: bool
+    requires_human_review: bool
+    reasons: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def phase_from_config(cfg: Dict[str, Any]) -> EvePhase:
+    deployment = cfg.get("deployment", {}) if cfg else {}
+    mode = str(deployment.get("mode", "simulation")).lower()
+    aliases = {"shadow_mainnet": EvePhase.SIMULATION, "mainnet": EvePhase.CONSTRAINED_MAINNET}
+    try:
+        return aliases.get(mode, EvePhase(mode))
+    except ValueError:
+        return EvePhase.SIMULATION
+
+
+def evaluate_phase(cfg: Dict[str, Any], *, human_reviewed: bool = False) -> PhaseDecision:
+    phase = phase_from_config(cfg)
+    reasons: List[str] = []
+    allowed_to_simulate = True
+    allowed_to_run_testnet = phase in {EvePhase.TESTNET, EvePhase.SANDBOX} and human_reviewed
+    allowed_to_run_constrained_live = phase is EvePhase.CONSTRAINED_MAINNET and human_reviewed
+
+    if not human_reviewed:
+        reasons.append("human_review_missing")
+    if phase is EvePhase.SIMULATION:
+        reasons.append("simulation_only")
+    if phase is EvePhase.TESTNET:
+        reasons.append("testnet_only")
+    if phase is EvePhase.SANDBOX:
+        reasons.append("sandbox_only")
+    if phase is EvePhase.CONSTRAINED_MAINNET and not human_reviewed:
+        reasons.append("constrained_live_requires_review")
+
+    return PhaseDecision(
+        phase=phase,
+        allowed_to_simulate=allowed_to_simulate,
+        allowed_to_run_testnet=allowed_to_run_testnet,
+        allowed_to_run_constrained_live=allowed_to_run_constrained_live,
+        requires_human_review=True,
+        reasons=reasons or ["approved_with_constraints"],
+    )

--- a/eve_q/risk/__init__.py
+++ b/eve_q/risk/__init__.py
@@ -1,0 +1,1 @@
+"""Risk and review gates for EVE_Q."""

--- a/eve_q/risk/charity_allocation_gate.py
+++ b/eve_q/risk/charity_allocation_gate.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List
+
+
+@dataclass(slots=True)
+class CharityGateResult:
+    allowed_to_record_balance: bool
+    allowed_to_release_funds: bool
+    requires_human_review: bool
+    block_reasons: List[str]
+    review_reasons: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def evaluate_charity_gate(
+    proposal: Dict[str, Any],
+    *,
+    human_reviewed: bool = False,
+    receipt_path_available: bool = False,
+) -> CharityGateResult:
+    block_reasons: List[str] = []
+    review_reasons: List[str] = []
+
+    provenance = proposal.get("provenance") or proposal.get("inputs", {}).get("provenance") or []
+    confidence = float(proposal.get("confidence_score", proposal.get("inputs", {}).get("confidence_score", 0.0)))
+    reliability = float(proposal.get("telemetry_source_reliability", proposal.get("inputs", {}).get("telemetry_source_reliability", 0.0)))
+
+    if not provenance:
+        block_reasons.append("missing_provenance")
+    if not human_reviewed:
+        block_reasons.append("human_review_missing")
+    if not receipt_path_available:
+        review_reasons.append("receipt_path_not_confirmed")
+    if confidence < 0.55:
+        review_reasons.append("low_confidence")
+    if reliability < 0.50:
+        review_reasons.append("low_source_reliability")
+    if proposal.get("requires_human_review"):
+        review_reasons.append("policy_requested_review")
+
+    return CharityGateResult(
+        allowed_to_record_balance=bool(provenance),
+        allowed_to_release_funds=len(block_reasons) == 0 and receipt_path_available,
+        requires_human_review=True,
+        block_reasons=block_reasons,
+        review_reasons=sorted(set(review_reasons)),
+    )

--- a/eve_q/telemetry/__init__.py
+++ b/eve_q/telemetry/__init__.py
@@ -1,0 +1,1 @@
+"""Need, impact, and source-confidence telemetry scoring."""

--- a/eve_q/telemetry/impact_score.py
+++ b/eve_q/telemetry/impact_score.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(slots=True)
+class ImpactSignal:
+    charity_id: str
+    receipt_quality: float = 0.0
+    historical_delivery_score: float = 0.0
+    cost_effectiveness_score: float = 0.0
+    transparency_score: float = 0.0
+    telemetry_source_reliability: float = 0.0
+    provenance: List[str] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def score_impact(signal: ImpactSignal) -> Dict[str, Any]:
+    receipt = clamp01(signal.receipt_quality)
+    delivery = clamp01(signal.historical_delivery_score)
+    cost_effectiveness = clamp01(signal.cost_effectiveness_score)
+    transparency = clamp01(signal.transparency_score)
+    reliability = clamp01(signal.telemetry_source_reliability)
+    provenance = signal.provenance or []
+    impact = clamp01(0.30 * receipt + 0.30 * delivery + 0.25 * cost_effectiveness + 0.15 * transparency)
+    confidence = clamp01((0.70 * reliability) + (0.30 if provenance else 0.0))
+    return {
+        "charity_id": signal.charity_id,
+        "impact_score": impact,
+        "receipt_quality": receipt,
+        "historical_delivery_score": delivery,
+        "cost_effectiveness_score": cost_effectiveness,
+        "transparency_score": transparency,
+        "confidence_score": confidence,
+        "telemetry_source_reliability": reliability,
+        "provenance": provenance,
+        "requires_human_review": confidence < 0.55 or not provenance,
+    }

--- a/eve_q/telemetry/need_score.py
+++ b/eve_q/telemetry/need_score.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(slots=True)
+class NeedSignal:
+    cause_id: str
+    region: str | None = None
+    funding_gap_score: float = 0.0
+    urgency_score: float = 0.0
+    population_affected_score: float = 0.0
+    neglect_factor: float = 0.0
+    time_sensitivity_score: float = 0.0
+    preventive_value_score: float = 0.0
+    regional_vulnerability_score: float = 0.0
+    absorptive_capacity_score: float = 0.0
+    telemetry_source_reliability: float = 0.0
+    provenance: List[str] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def score_need(signal: NeedSignal) -> Dict[str, Any]:
+    funding_gap = clamp01(signal.funding_gap_score)
+    urgency = clamp01(signal.urgency_score)
+    affected = clamp01(signal.population_affected_score)
+    neglect = clamp01(signal.neglect_factor)
+    time_sensitivity = clamp01(signal.time_sensitivity_score)
+    preventive = clamp01(signal.preventive_value_score)
+    vulnerability = clamp01(signal.regional_vulnerability_score)
+    absorb = clamp01(signal.absorptive_capacity_score)
+    reliability = clamp01(signal.telemetry_source_reliability)
+    provenance = signal.provenance or []
+
+    raw_need = (
+        0.20 * funding_gap
+        + 0.20 * urgency
+        + 0.15 * affected
+        + 0.15 * neglect
+        + 0.10 * time_sensitivity
+        + 0.10 * preventive
+        + 0.10 * vulnerability
+    )
+    confidence = clamp01((0.70 * reliability) + (0.30 if provenance else 0.0))
+
+    return {
+        "cause_id": signal.cause_id,
+        "region": signal.region,
+        "need_score": clamp01(raw_need),
+        "funding_gap_score": funding_gap,
+        "urgency_score": urgency,
+        "population_affected_score": affected,
+        "neglect_factor": neglect,
+        "time_sensitivity_score": time_sensitivity,
+        "preventive_value_score": preventive,
+        "regional_vulnerability_score": vulnerability,
+        "absorptive_capacity_score": absorb,
+        "confidence_score": confidence,
+        "telemetry_source_reliability": reliability,
+        "provenance": provenance,
+        "requires_human_review": confidence < 0.55 or not provenance,
+    }

--- a/eve_q/telemetry/source_confidence.py
+++ b/eve_q/telemetry/source_confidence.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+@dataclass(slots=True)
+class SourceConfidenceInput:
+    source_name: str
+    historical_accuracy: float = 0.5
+    recency_score: float = 0.5
+    independence_score: float = 0.5
+    provenance_quality: float = 0.0
+    conflict_penalty: float = 0.0
+
+
+def score_source_confidence(signal: SourceConfidenceInput) -> float:
+    score = (
+        0.30 * clamp01(signal.historical_accuracy)
+        + 0.20 * clamp01(signal.recency_score)
+        + 0.25 * clamp01(signal.independence_score)
+        + 0.25 * clamp01(signal.provenance_quality)
+        - 0.35 * clamp01(signal.conflict_penalty)
+    )
+    return clamp01(score)

--- a/omega_telemetry/__init__.py
+++ b/omega_telemetry/__init__.py
@@ -1,17 +1,16 @@
 """Omega telemetry package.
 
-Shadow-first telemetry surfaces for observing market context before any action layer.
+Shadow-first signal surfaces for observing context before any action layer.
 """
 
-from .config_loader import load_config
-from .models import Event, WhaleEvent, SentimentEvent, AlertResult, PricePoint
+from .config_tools import load_config
+from .models import Event, SentimentEvent, AlertResult, PricePoint
 from .db import TelemetryDB
 from .health import HealthWriter
 
 __all__ = [
     "load_config",
     "Event",
-    "WhaleEvent",
     "SentimentEvent",
     "AlertResult",
     "PricePoint",

--- a/omega_telemetry/__init__.py
+++ b/omega_telemetry/__init__.py
@@ -1,0 +1,20 @@
+"""Omega telemetry package.
+
+Shadow-first telemetry surfaces for observing market context before any action layer.
+"""
+
+from .config_loader import load_config
+from .models import Event, WhaleEvent, SentimentEvent, AlertResult, PricePoint
+from .db import TelemetryDB
+from .health import HealthWriter
+
+__all__ = [
+    "load_config",
+    "Event",
+    "WhaleEvent",
+    "SentimentEvent",
+    "AlertResult",
+    "PricePoint",
+    "TelemetryDB",
+    "HealthWriter",
+]

--- a/omega_telemetry/alert_module.py
+++ b/omega_telemetry/alert_module.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List
+
+import aiohttp
+
+from .db import TelemetryDB
+from .models import AlertResult, Event
+
+logger = logging.getLogger(__name__)
+
+
+def format_event_message(event: Event) -> str:
+    prefix = {
+        "critical": "🚨",
+        "high": "⚠️",
+        "medium": "🔎",
+        "low": "ℹ️",
+    }.get(event.severity, "ℹ️")
+    lines = [
+        f"{prefix} {event.title}",
+        event.summary,
+        f"Type: {event.event_type}",
+    ]
+    if event.chain:
+        lines.append(f"Chain: {event.chain}")
+    lines.append(f"Time: {event.occurred_at}")
+    extra = event.data or {}
+    if "tx_hash" in extra:
+        lines.append(f"Tx: {extra['tx_hash']}")
+    if "source_url" in extra:
+        lines.append(f"Link: {extra['source_url']}")
+    return "\n".join(lines)
+
+
+class AlertDispatcher:
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        db: TelemetryDB,
+        config: Dict[str, Any],
+        shadow_mode: bool = True,
+    ) -> None:
+        self.session = session
+        self.db = db
+        self.config = config
+        self.shadow_mode = shadow_mode
+
+    async def dispatch(self, event: Event) -> List[AlertResult]:
+        if self.shadow_mode:
+            logger.info("SHADOW ALERT\n%s", format_event_message(event))
+            result = AlertResult(channel="shadow", delivered=True, response="shadow_mode")
+            self.db.log_alert(event.dedupe_key, result.channel, result.delivered, result.response)
+            return [result]
+
+        results: List[AlertResult] = []
+        telegram_cfg = self.config.get("telegram", {})
+        discord_cfg = self.config.get("discord", {})
+
+        if telegram_cfg.get("enabled"):
+            results.append(await self._send_telegram(event, telegram_cfg))
+        if discord_cfg.get("enabled"):
+            results.append(await self._send_discord(event, discord_cfg))
+
+        if not results:
+            result = AlertResult(channel="shadow-fallback", delivered=False, response="no_channels_configured")
+            self.db.log_alert(event.dedupe_key, result.channel, result.delivered, result.response)
+            return [result]
+
+        for result in results:
+            self.db.log_alert(event.dedupe_key, result.channel, result.delivered, result.response)
+        return results
+
+    async def _send_telegram(self, event: Event, cfg: Dict[str, Any]) -> AlertResult:
+        token = cfg.get("bot_token")
+        chat_id = cfg.get("chat_id")
+        if not token or not chat_id:
+            return AlertResult(channel="telegram", delivered=False, response="missing_telegram_credentials")
+
+        url = f"https://api.telegram.org/bot{token}/sendMessage"
+        payload = {
+            "chat_id": chat_id,
+            "text": format_event_message(event),
+            "disable_web_page_preview": True,
+        }
+        try:
+            async with self.session.post(url, json=payload) as resp:
+                text = await resp.text()
+                delivered = 200 <= resp.status < 300
+                return AlertResult(channel="telegram", delivered=delivered, response=text[:500])
+        except Exception as exc:
+            return AlertResult(channel="telegram", delivered=False, response=f"{type(exc).__name__}: {exc}")
+
+    async def _send_discord(self, event: Event, cfg: Dict[str, Any]) -> AlertResult:
+        webhook_url = cfg.get("webhook_url")
+        if not webhook_url:
+            return AlertResult(channel="discord", delivered=False, response="missing_discord_webhook")
+
+        try:
+            async with self.session.post(webhook_url, json={"content": format_event_message(event)}) as resp:
+                text = await resp.text()
+                delivered = 200 <= resp.status < 300
+                return AlertResult(channel="discord", delivered=delivered, response=text[:500])
+        except Exception as exc:
+            return AlertResult(channel="discord", delivered=False, response=f"{type(exc).__name__}: {exc}")

--- a/omega_telemetry/config_loader.py
+++ b/omega_telemetry/config_loader.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .config_tools import load_config
+
+__all__ = ["load_config"]

--- a/omega_telemetry/config_tools.py
+++ b/omega_telemetry/config_tools.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str | Path) -> Dict[str, Any]:
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as handle:
+        payload = yaml.safe_load(handle) or {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload

--- a/omega_telemetry/context_runner.py
+++ b/omega_telemetry/context_runner.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+import aiohttp
+
+from .config_tools import load_config
+from .db import TelemetryDB
+from .health import HealthWriter
+from .sentiment_tracker import SentimentTracker
+from .signal_observer import SignalObserver
+
+logger = logging.getLogger(__name__)
+
+
+async def run(config_path: str) -> None:
+    cfg = load_config(config_path)
+    logging.basicConfig(
+        level=getattr(logging, str(cfg.get("log_level", "INFO")).upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    db = TelemetryDB(str(cfg.get("database_path", "data/omega_telemetry.sqlite")))
+    health = HealthWriter(str(cfg.get("health_path", "logs/omega_health.json")))
+
+    async with aiohttp.ClientSession() as session:
+        tasks: List[asyncio.Task[Any]] = []
+
+        for observer_cfg in cfg.get("observers", []):
+            if observer_cfg.get("enabled", True):
+                observer = SignalObserver(db, observer_cfg)
+                tasks.append(asyncio.create_task(observer.run_forever()))
+
+        signal_cfg: Dict[str, Any] = cfg.get("sentiment", {})
+        rules_path = str(signal_cfg.get("rules_path", "rules/market_signal_rules.json"))
+        if signal_cfg.get("enabled", False) and Path(rules_path).exists():
+            tracker = SentimentTracker(session, db, signal_cfg, rules_path)
+            tasks.append(asyncio.create_task(tracker.run_forever()))
+
+        async def heartbeat() -> None:
+            while True:
+                health.write({"status": "ok", "tasks": len(tasks)})
+                await asyncio.sleep(int(cfg.get("health_interval_seconds", 30)))
+
+        tasks.append(asyncio.create_task(heartbeat()))
+        await asyncio.gather(*tasks)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run passive context telemetry.")
+    parser.add_argument("--config", default="config/omega.example.yaml")
+    args = parser.parse_args()
+    asyncio.run(run(args.config))
+
+
+if __name__ == "__main__":
+    main()

--- a/omega_telemetry/db.py
+++ b/omega_telemetry/db.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+from .models import Event
+
+
+class TelemetryDB:
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    @contextmanager
+    def connect(self) -> Iterator[sqlite3.Connection]:
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _init_db(self) -> None:
+        with self.connect() as conn:
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_type TEXT NOT NULL,
+                    chain_name TEXT,
+                    source TEXT NOT NULL,
+                    severity TEXT NOT NULL,
+                    occurred_at TEXT NOT NULL,
+                    dedupe_key TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    summary TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_events_dedupe
+                ON events (dedupe_key, occurred_at);
+
+                CREATE TABLE IF NOT EXISTS state (
+                    state_key TEXT PRIMARY KEY,
+                    state_value TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS alert_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    dedupe_key TEXT NOT NULL,
+                    channel TEXT NOT NULL,
+                    delivered INTEGER NOT NULL,
+                    response TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_alert_log_dedupe
+                ON alert_log (dedupe_key, created_at);
+                """
+            )
+
+    def save_event(self, event: Event) -> None:
+        record = event.to_record()
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO events (
+                    event_type, chain_name, source, severity, occurred_at,
+                    dedupe_key, title, summary, payload_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record["event_type"],
+                    record["chain"],
+                    record["source"],
+                    record["severity"],
+                    record["occurred_at"],
+                    record["dedupe_key"],
+                    record["title"],
+                    record["summary"],
+                    json.dumps(record, ensure_ascii=False),
+                ),
+            )
+
+    def is_duplicate(self, dedupe_key: str, cooldown_minutes: int) -> bool:
+        cutoff = (datetime.now(timezone.utc) - timedelta(minutes=cooldown_minutes)).isoformat()
+        with self.connect() as conn:
+            row = conn.execute(
+                """
+                SELECT 1 FROM events
+                WHERE dedupe_key = ? AND occurred_at >= ?
+                LIMIT 1
+                """,
+                (dedupe_key, cutoff),
+            ).fetchone()
+        return row is not None
+
+    def log_alert(self, dedupe_key: str, channel: str, delivered: bool, response: str) -> None:
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO alert_log (dedupe_key, channel, delivered, response, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    dedupe_key,
+                    channel,
+                    1 if delivered else 0,
+                    response,
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+
+    def set_state(self, key: str, value: str) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO state (state_key, state_value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(state_key)
+                DO UPDATE SET state_value = excluded.state_value, updated_at = excluded.updated_at
+                """,
+                (key, value, now),
+            )
+
+    def get_state(self, key: str) -> Optional[str]:
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT state_value FROM state WHERE state_key = ?",
+                (key,),
+            ).fetchone()
+        return None if row is None else str(row["state_value"])
+
+    def recent_events(self, event_type: Optional[str] = None, minutes: int = 60) -> List[Dict[str, Any]]:
+        cutoff = (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+        sql = """
+            SELECT payload_json FROM events
+            WHERE occurred_at >= ?
+        """
+        params: list[Any] = [cutoff]
+        if event_type:
+            sql += " AND event_type = ?"
+            params.append(event_type)
+        sql += " ORDER BY occurred_at DESC"
+        with self.connect() as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [json.loads(row["payload_json"]) for row in rows]

--- a/omega_telemetry/health.py
+++ b/omega_telemetry/health.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+
+class HealthWriter:
+    def __init__(self, path: str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write(self, payload: Dict[str, Any]) -> None:
+        body = {
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            **payload,
+        }
+        self.path.write_text(json.dumps(body, indent=2), encoding="utf-8")

--- a/omega_telemetry/models.py
+++ b/omega_telemetry/models.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso_now() -> str:
+    return utc_now().isoformat()
+
+
+@dataclass(slots=True)
+class Event:
+    event_type: str
+    chain: Optional[str]
+    source: str
+    severity: str
+    occurred_at: str
+    dedupe_key: str
+    title: str
+    summary: str
+    data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(slots=True)
+class WhaleEvent(Event):
+    amount: Optional[str] = None
+    asset_symbol: Optional[str] = None
+    usd_value: Optional[str] = None
+    from_address: Optional[str] = None
+    to_address: Optional[str] = None
+    from_label: Optional[str] = None
+    to_label: Optional[str] = None
+    tx_hash: Optional[str] = None
+
+
+@dataclass(slots=True)
+class SentimentEvent(Event):
+    post_id: Optional[str] = None
+    source_url: Optional[str] = None
+    author: Optional[str] = None
+    score_value: Optional[float] = None
+    matched_rules: List[str] = field(default_factory=list)
+    tickers: List[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class AlertResult:
+    channel: str
+    delivered: bool
+    response: str
+
+
+@dataclass(slots=True)
+class PricePoint:
+    symbol: str
+    usd: Decimal
+    source: str
+    observed_at: str = field(default_factory=iso_now)

--- a/omega_telemetry/models.py
+++ b/omega_telemetry/models.py
@@ -31,7 +31,7 @@ class Event:
 
 
 @dataclass(slots=True)
-class WhaleEvent(Event):
+class ChainSignalEvent(Event):
     amount: Optional[str] = None
     asset_symbol: Optional[str] = None
     usd_value: Optional[str] = None

--- a/omega_telemetry/pricing.py
+++ b/omega_telemetry/pricing.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Dict, Optional
+
+import aiohttp
+
+from .models import PricePoint
+
+
+class PriceResolver:
+    """CoinGecko-backed USD price resolver for telemetry context."""
+
+    COINGECKO_SIMPLE_PRICE = "https://api.coingecko.com/api/v3/simple/price"
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        symbol_to_id: Dict[str, str],
+        timeout_seconds: int = 15,
+    ) -> None:
+        self.session = session
+        self.symbol_to_id = {k.upper(): v for k, v in symbol_to_id.items()}
+        self.timeout_seconds = timeout_seconds
+        self._cache: Dict[str, PricePoint] = {}
+
+    async def get_usd_price(self, symbol: str) -> Optional[PricePoint]:
+        symbol_up = symbol.upper()
+        if symbol_up in self._cache:
+            return self._cache[symbol_up]
+
+        coin_id = self.symbol_to_id.get(symbol_up)
+        if not coin_id:
+            return None
+
+        params = {"ids": coin_id, "vs_currencies": "usd"}
+        timeout = aiohttp.ClientTimeout(total=self.timeout_seconds)
+        async with self.session.get(self.COINGECKO_SIMPLE_PRICE, params=params, timeout=timeout) as resp:
+            resp.raise_for_status()
+            payload: Dict[str, Any] = await resp.json()
+
+        usd = payload.get(coin_id, {}).get("usd")
+        if usd is None:
+            return None
+
+        point = PricePoint(symbol=symbol_up, usd=Decimal(str(usd)), source="coingecko")
+        self._cache[symbol_up] = point
+        return point

--- a/omega_telemetry/sentiment_tracker.py
+++ b/omega_telemetry/sentiment_tracker.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Tuple
+
+import aiohttp
+import feedparser
+
+from .db import TelemetryDB
+from .models import SentimentEvent
+
+logger = logging.getLogger(__name__)
+
+TICKER_RE = re.compile(r"(?<!\w)\$([A-Z]{2,10})(?!\w)")
+
+
+@dataclass(slots=True)
+class Rule:
+    name: str
+    category: str
+    weight: float
+    patterns: List[str]
+    case_sensitive: bool = False
+
+
+class RuleEngine:
+    def __init__(self, rule_payload: Dict[str, Any]) -> None:
+        self.rules: List[Rule] = []
+        for item in rule_payload.get("rules", []):
+            self.rules.append(
+                Rule(
+                    name=item["name"],
+                    category=item["category"],
+                    weight=float(item["weight"]),
+                    patterns=list(item["patterns"]),
+                    case_sensitive=bool(item.get("case_sensitive", False)),
+                )
+            )
+
+    def score(self, text: str) -> Tuple[float, List[str]]:
+        total = 0.0
+        matched: List[str] = []
+        for rule in self.rules:
+            haystack = text if rule.case_sensitive else text.lower()
+            patterns = rule.patterns if rule.case_sensitive else [p.lower() for p in rule.patterns]
+            if any(pattern in haystack for pattern in patterns):
+                total += rule.weight
+                matched.append(rule.name)
+        return total, matched
+
+
+class FeedAdapter:
+    def __init__(self, session: aiohttp.ClientSession, source_cfg: Dict[str, Any]) -> None:
+        self.session = session
+        self.source_cfg = source_cfg
+
+    async def fetch_items(self) -> List[Dict[str, Any]]:
+        source_type = self.source_cfg["type"]
+        if source_type == "rss":
+            return await self._fetch_rss()
+        if source_type == "json":
+            return await self._fetch_json()
+        raise ValueError(f"Unsupported sentiment source type: {source_type}")
+
+    async def _fetch_rss(self) -> List[Dict[str, Any]]:
+        url = self.source_cfg["url"]
+        async with self.session.get(url, timeout=aiohttp.ClientTimeout(total=20)) as resp:
+            resp.raise_for_status()
+            text = await resp.text()
+        parsed = feedparser.parse(text)
+        items: List[Dict[str, Any]] = []
+        for entry in parsed.entries:
+            items.append(
+                {
+                    "id": entry.get("id") or entry.get("link") or entry.get("title"),
+                    "title": entry.get("title", ""),
+                    "summary": entry.get("summary", ""),
+                    "url": entry.get("link", ""),
+                    "author": entry.get("author", ""),
+                    "published": entry.get("published", ""),
+                }
+            )
+        return items
+
+    async def _fetch_json(self) -> List[Dict[str, Any]]:
+        url = self.source_cfg["url"]
+        items_path = self.source_cfg.get("items_path", [])
+        async with self.session.get(url, timeout=aiohttp.ClientTimeout(total=20)) as resp:
+            resp.raise_for_status()
+            payload = await resp.json()
+        cursor: Any = payload
+        for part in items_path:
+            cursor = cursor[part]
+        if not isinstance(cursor, list):
+            raise ValueError("JSON adapter items_path did not resolve to a list")
+        return list(cursor)
+
+
+class SentimentTracker:
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        db: TelemetryDB,
+        config: Dict[str, Any],
+        rules_path: str,
+    ) -> None:
+        self.session = session
+        self.db = db
+        self.config = config
+        self.cooldown_minutes = int(config.get("cooldown_minutes", 10))
+        self.poll_interval_seconds = int(config.get("poll_interval_seconds", 60))
+        self.min_score = float(config.get("min_score", 3.0))
+        self.spike_window_minutes = int(config.get("spike_window_minutes", 15))
+        self.spike_threshold_count = int(config.get("spike_threshold_count", 5))
+        with open(rules_path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+        self.rules = RuleEngine(payload)
+        self.adapters = [FeedAdapter(session, src) for src in config.get("sources", [])]
+
+    async def run_forever(self) -> None:
+        logger.info("Sentiment tracker starting")
+        while True:
+            try:
+                await self.poll_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Sentiment tracker loop error")
+            await asyncio.sleep(self.poll_interval_seconds)
+
+    async def poll_once(self) -> None:
+        for adapter in self.adapters:
+            items = await adapter.fetch_items()
+            for item in items:
+                await self._process_item(item, adapter.source_cfg.get("name", "unknown"))
+        await self._emit_spike_events()
+
+    async def _process_item(self, item: Dict[str, Any], source_name: str) -> None:
+        text_parts = [item.get("title", ""), item.get("summary", "")]
+        text = "\n".join(part for part in text_parts if part).strip()
+        if not text:
+            return
+
+        score_value, matched_rules = self.rules.score(text)
+        if score_value < self.min_score:
+            return
+
+        tickers = sorted(set(TICKER_RE.findall(text)))
+        severity = "critical" if score_value >= self.min_score * 3 else "high" if score_value >= self.min_score * 2 else "medium"
+        dedupe_key = f"sentiment:{source_name}:{item.get('id')}"
+        if self.db.is_duplicate(dedupe_key, self.cooldown_minutes):
+            return
+
+        ticker_text = f" | tickers: {', '.join(tickers)}" if tickers else ""
+        event = SentimentEvent(
+            event_type="sentiment_match",
+            chain=None,
+            source=source_name,
+            severity=severity,
+            occurred_at=datetime.now(timezone.utc).isoformat(),
+            dedupe_key=dedupe_key,
+            title=f"Sentiment signal from {source_name}",
+            summary=f"score={score_value:.1f}, rules={', '.join(matched_rules)}{ticker_text}",
+            data={
+                "post_id": item.get("id"),
+                "source_url": item.get("url"),
+                "author": item.get("author"),
+                "score_value": score_value,
+                "matched_rules": matched_rules,
+                "tickers": tickers,
+                "raw_title": item.get("title", ""),
+            },
+            post_id=item.get("id"),
+            source_url=item.get("url"),
+            author=item.get("author"),
+            score_value=score_value,
+            matched_rules=matched_rules,
+            tickers=tickers,
+        )
+        self.db.save_event(event)
+        logger.info("Sentiment event: %s", event.summary)
+
+    async def _emit_spike_events(self) -> None:
+        recent = self.db.recent_events(event_type="sentiment_match", minutes=self.spike_window_minutes)
+        ticker_counts: Dict[str, int] = {}
+        for event in recent:
+            tickers = event.get("tickers") or event.get("data", {}).get("tickers") or []
+            for ticker in tickers:
+                ticker_counts[ticker] = ticker_counts.get(ticker, 0) + 1
+
+        for ticker, count in ticker_counts.items():
+            if count < self.spike_threshold_count:
+                continue
+            dedupe_key = f"sentiment_spike:{ticker}:{self.spike_window_minutes}"
+            if self.db.is_duplicate(dedupe_key, self.cooldown_minutes):
+                continue
+            event = SentimentEvent(
+                event_type="sentiment_spike",
+                chain=None,
+                source="burst_detector",
+                severity="high" if count < self.spike_threshold_count * 2 else "critical",
+                occurred_at=datetime.now(timezone.utc).isoformat(),
+                dedupe_key=dedupe_key,
+                title=f"Sentiment spike for ${ticker}",
+                summary=f"{count} tracked posts in the last {self.spike_window_minutes} minutes crossed the spike threshold.",
+                data={"ticker": ticker, "count": count, "window_minutes": self.spike_window_minutes},
+                post_id=None,
+                source_url=None,
+                author=None,
+                score_value=float(count),
+                matched_rules=["burst_detector"],
+                tickers=[ticker],
+            )
+            self.db.save_event(event)
+            logger.info("Sentiment spike: %s -> %s", ticker, count)

--- a/omega_telemetry/signal_observer.py
+++ b/omega_telemetry/signal_observer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from .db import TelemetryDB
+from .models import Event
+
+logger = logging.getLogger(__name__)
+
+
+class SignalObserver:
+    """Neutral context observer scaffold.
+
+    This class records periodic context ticks into the local event store. It is
+    intentionally read-only and contains no action hooks.
+    """
+
+    def __init__(self, db: TelemetryDB, config: Dict[str, Any]) -> None:
+        self.db = db
+        self.config = config
+        self.name = str(config.get("name", "signal"))
+        self.poll_interval_seconds = int(config.get("poll_interval_seconds", 30))
+
+    async def run_forever(self) -> None:
+        logger.info("Signal observer starting for %s", self.name)
+        while True:
+            try:
+                await self.poll_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Signal observer loop error for %s", self.name)
+            await asyncio.sleep(self.poll_interval_seconds)
+
+    async def poll_once(self) -> None:
+        observed_at = datetime.now(timezone.utc).isoformat()
+        event = Event(
+            event_type="signal_tick",
+            chain=None,
+            source=self.name,
+            severity="low",
+            occurred_at=observed_at,
+            dedupe_key=f"signal_tick:{self.name}:{observed_at}",
+            title=f"{self.name} signal tick",
+            summary="Context observer heartbeat recorded.",
+            data={"observer": self.name},
+        )
+        self.db.save_event(event)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-flake8
-black
-pytest
+aiohttp>=3.9.0
+PyYAML>=6.0.1
+feedparser>=6.0.11
+pytest>=8.0.0

--- a/rules/market_signal_rules.json
+++ b/rules/market_signal_rules.json
@@ -1,0 +1,40 @@
+{
+  "rules": [
+    {
+      "name": "security_notice",
+      "category": "system_status",
+      "weight": 5,
+      "patterns": ["security notice", "incident report", "postmortem", "service paused"]
+    },
+    {
+      "name": "liquidity_change",
+      "category": "market_structure",
+      "weight": 3,
+      "patterns": ["liquidity change", "pool update", "reserve change", "routing update"]
+    },
+    {
+      "name": "venue_flow",
+      "category": "market_structure",
+      "weight": 3,
+      "patterns": ["venue inflow", "venue outflow", "custody update", "settlement update"]
+    },
+    {
+      "name": "governance_activity",
+      "category": "governance",
+      "weight": 2,
+      "patterns": ["proposal", "governance vote", "treasury vote", "delegate update"]
+    },
+    {
+      "name": "volatility_notice",
+      "category": "market_structure",
+      "weight": 2,
+      "patterns": ["volatility", "price dislocation", "spread widening", "funding reset"]
+    },
+    {
+      "name": "public_interest",
+      "category": "attention",
+      "weight": 1,
+      "patterns": ["trending", "public interest", "social volume", "attention spike"]
+    }
+  ]
+}

--- a/tests/test_need_impact_scoring.py
+++ b/tests/test_need_impact_scoring.py
@@ -1,0 +1,24 @@
+from eve_q.telemetry.need_score import NeedSignal, score_need
+from eve_q.telemetry.impact_score import ImpactSignal, score_impact
+
+
+def test_need_score_requires_review_without_provenance():
+    result = score_need(NeedSignal(cause_id="famine", urgency_score=1.0, telemetry_source_reliability=0.9))
+    assert result["need_score"] > 0
+    assert result["requires_human_review"] is True
+
+
+def test_impact_score_uses_receipt_and_delivery():
+    result = score_impact(
+        ImpactSignal(
+            charity_id="kitchen",
+            receipt_quality=0.9,
+            historical_delivery_score=0.8,
+            cost_effectiveness_score=0.7,
+            transparency_score=0.9,
+            telemetry_source_reliability=0.9,
+            provenance=["receipt:abc"],
+        )
+    )
+    assert result["impact_score"] > 0.75
+    assert result["requires_human_review"] is False

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,28 @@
+def test_omega_package_import_surface():
+    import omega_telemetry
+    from omega_telemetry import Event, PricePoint, TelemetryDB, HealthWriter, load_config
+    from omega_telemetry.models import ChainSignalEvent
+
+    assert omega_telemetry is not None
+    assert Event is not None
+    assert ChainSignalEvent is not None
+    assert PricePoint is not None
+    assert TelemetryDB is not None
+    assert HealthWriter is not None
+    assert load_config is not None
+
+
+def test_eve_q_package_import_surface():
+    from eve_q.allocation.geodesic_policy import GeodesicInput, score_allocation
+    from eve_q.gates.eve_phase import EvePhase, evaluate_phase
+    from eve_q.telemetry.need_score import NeedSignal, score_need
+    from eve_q.telemetry.impact_score import ImpactSignal, score_impact
+
+    assert GeodesicInput is not None
+    assert score_allocation is not None
+    assert EvePhase is not None
+    assert evaluate_phase is not None
+    assert NeedSignal is not None
+    assert score_need is not None
+    assert ImpactSignal is not None
+    assert score_impact is not None


### PR DESCRIPTION
## Summary

Adds a package scaffold for EVE_Q and Omega.

Included:
- EVE_Q allocation, gate, risk, and telemetry modules
- Omega context package with models, local event store, health writer, config helpers, passive runner, and observer scaffold
- Market signal rules and example config
- Basic package import tests

## Notes

This PR keeps the scaffold passive and review oriented. Main remains untouched until this draft is reviewed.