### PR TITLE
Add charity allocation diversity guard

### DIFF
--- a/eve_q/allocation/charity_router.py
+++ b/eve_q/allocation/charity_router.py
@@ -1,15 +1,163 @@
+"""Charity allocation router with portfolio diversity safeguards.
+
+The router proposes allocation weights only. It does not release funds,
+execute transfers, sign transactions, touch wallets, or authorize capital movement.
+
+Core law:
+Verified impact bends the gradient.
+It does not own the gradient.
+No single charity may become the whole definition of good.
+"""
+
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List
+from dataclasses import dataclass
 
-from eve_q.allocation.geodesic_policy import GeodesicInput, score_allocation
+from eve_q.allocation.geodesic_policy import score_allocation
+
+EPSILON = 1e-12
 
 
-def propose_allocations(signals: Iterable[GeodesicInput]) -> List[Dict[str, Any]]:
+@dataclass(frozen=True)
+class AllocationDiversityPolicy:
+    """Policy envelope for graceful allocation degradation.
+
+    The policy does not punish a high-impact charity. It caps concentration,
+    reserves exploration budget, and routes concentrated proposals toward
+    human review instead of allowing a monoculture.
+    """
+
+    max_single_charity_weight: float = 0.45
+    exploration_budget: float = 0.10
+    concentration_review_threshold: float = 0.40
+
+
+DEFAULT_POLICY = AllocationDiversityPolicy()
+
+
+def _validate_policy(policy: AllocationDiversityPolicy) -> None:
+    if not 0.0 <= policy.max_single_charity_weight <= 1.0:
+        raise ValueError("max_single_charity_weight must be between 0 and 1")
+    if not 0.0 <= policy.exploration_budget <= 1.0:
+        raise ValueError("exploration_budget must be between 0 and 1")
+    if not 0.0 <= policy.concentration_review_threshold <= 1.0:
+        raise ValueError("concentration_review_threshold must be between 0 and 1")
+
+
+def _safe_weight(decision: dict) -> float:
+    return max(0.0, float(decision.get("recommended_weight", 0.0)))
+
+
+def _raw_normalized_weights(decisions: list[dict]) -> list[float]:
+    weights = [_safe_weight(decision) for decision in decisions]
+    total = sum(weights)
+    if total <= EPSILON:
+        return [0.0 for _ in weights]
+    return [weight / total for weight in weights]
+
+
+def _capped_guarded_weights(
+    normalized_weights: list[float],
+    policy: AllocationDiversityPolicy,
+) -> tuple[list[float], float]:
+    """Apply graceful concentration cap and reserve exploration budget.
+
+    Returns:
+      guarded weights assigned to current candidates
+      unallocated residual caused by caps
+    """
+
+    allocation_pool = max(0.0, 1.0 - policy.exploration_budget)
+    base_weights = [weight * allocation_pool for weight in normalized_weights]
+    guarded = [min(weight, policy.max_single_charity_weight) for weight in base_weights]
+
+    leftover = allocation_pool - sum(guarded)
+
+    while leftover > EPSILON:
+        eligible = [
+            index
+            for index, weight in enumerate(guarded)
+            if weight < policy.max_single_charity_weight - EPSILON and base_weights[index] > EPSILON
+        ]
+        if not eligible:
+            break
+
+        eligible_base_total = sum(base_weights[index] for index in eligible)
+        if eligible_base_total <= EPSILON:
+            break
+
+        previous_leftover = leftover
+
+        for index in eligible:
+            share = base_weights[index] / eligible_base_total
+            proposed = guarded[index] + previous_leftover * share
+            guarded[index] = min(proposed, policy.max_single_charity_weight)
+
+        leftover = allocation_pool - sum(guarded)
+        if abs(previous_leftover - leftover) <= EPSILON:
+            break
+
+    return guarded, max(0.0, leftover)
+
+
+def _add_review_reason(decision: dict, reason: str) -> None:
+    reasons = decision.setdefault("human_review_reasons", [])
+    if reason not in reasons:
+        reasons.append(reason)
+    decision["requires_human_review"] = True
+
+
+def propose_allocations(
+    signals,
+    policy: AllocationDiversityPolicy = DEFAULT_POLICY,
+):
+    """Return ranked allocation proposals with graceful degradation metadata.
+
+    This function proposes weights only. It keeps transfer posture held and
+    review-first. Concentration is degraded gracefully by capping recommended
+    weights and reserving exploration budget instead of hard-stopping the
+    entire allocation process.
+    """
+
+    _validate_policy(policy)
+
     decisions = [score_allocation(signal).to_dict() for signal in signals]
-    total = sum(d["recommended_weight"] for d in decisions)
-    for decision in decisions:
-        decision["normalized_recommended_weight"] = (
-            decision["recommended_weight"] / total if total > 0 else 0.0
-        )
-    return sorted(decisions, key=lambda d: d["allocation_priority"], reverse=True)
+    normalized_weights = _raw_normalized_weights(decisions)
+    guarded_weights, unallocated_due_to_caps = _capped_guarded_weights(
+        normalized_weights,
+        policy,
+    )
+
+    allocation_pool = max(0.0, 1.0 - policy.exploration_budget)
+
+    for decision, normalized, guarded in zip(
+        decisions,
+        normalized_weights,
+        guarded_weights,
+        strict=True,
+    ):
+        decision["normalized_recommended_weight"] = normalized
+        decision["guarded_recommended_weight"] = guarded
+        decision["reserved_exploration_weight"] = policy.exploration_budget
+        decision["portfolio_guard"] = {
+            "max_single_charity_weight": policy.max_single_charity_weight,
+            "exploration_budget_reserved": policy.exploration_budget,
+            "allocation_pool": allocation_pool,
+            "unallocated_due_to_caps": unallocated_due_to_caps,
+            "human_review_required_for_promotion": True,
+        }
+
+        # Proposals remain review-first. This router never authorizes transfer.
+        decision["hold_transfer"] = True
+
+        if normalized >= policy.concentration_review_threshold:
+            _add_review_reason(decision, "concentration_review_required")
+
+        if guarded + EPSILON < normalized * allocation_pool:
+            _add_review_reason(decision, "single_charity_cap_applied")
+
+    return sorted(
+        decisions,
+        key=lambda decision: decision.get("allocation_priority", 0.0),
+        reverse=True,
+    )

--- a/tests/test_charity_allocation_diversity_guard.py
+++ b/tests/test_charity_allocation_diversity_guard.py
@@ -1,0 +1,129 @@
+import pytest
+
+from eve_q.allocation.charity_router import (
+    AllocationDiversityPolicy,
+    propose_allocations,
+)
+from eve_q.allocation.geodesic_policy import GeodesicInput
+
+
+def signal(
+    charity_id,
+    *,
+    impact=0.8,
+    need=0.8,
+    urgency=0.8,
+    neglect=0.8,
+    funding_gap=0.8,
+    absorptive_capacity=0.8,
+    confidence=0.9,
+    reliability=0.9,
+    provenance="verified-receipt",
+):
+    return GeodesicInput(
+        charity_id=charity_id,
+        impact_score=impact,
+        need_score=need,
+        urgency_score=urgency,
+        neglect_factor=neglect,
+        funding_gap_score=funding_gap,
+        absorptive_capacity_score=absorptive_capacity,
+        confidence_score=confidence,
+        telemetry_source_reliability=reliability,
+        provenance=provenance,
+    )
+
+
+def test_guarded_weight_caps_dominant_charity_and_reserves_exploration():
+    policy = AllocationDiversityPolicy(
+        max_single_charity_weight=0.45,
+        exploration_budget=0.10,
+        concentration_review_threshold=0.40,
+    )
+
+    decisions = propose_allocations(
+        [
+            signal("dominant", impact=1.0, need=1.0, urgency=1.0),
+            signal("secondary", impact=0.25, need=0.25, urgency=0.25),
+            signal("ancillary", impact=0.20, need=0.20, urgency=0.20),
+        ],
+        policy=policy,
+    )
+
+    guarded_weights = [decision["guarded_recommended_weight"] for decision in decisions]
+
+    assert max(guarded_weights) <= 0.45 + 1e-9
+    assert sum(guarded_weights) <= 0.90 + 1e-9
+    assert all(
+        decision["reserved_exploration_weight"] == pytest.approx(0.10) for decision in decisions
+    )
+
+    dominant = next(decision for decision in decisions if decision["charity_id"] == "dominant")
+    assert "single_charity_cap_applied" in dominant["human_review_reasons"]
+    assert "concentration_review_required" in dominant["human_review_reasons"]
+    assert dominant["requires_human_review"] is True
+
+
+def test_router_preserves_raw_normalized_signal_separate_from_guarded_signal():
+    policy = AllocationDiversityPolicy(max_single_charity_weight=0.50)
+
+    decisions = propose_allocations(
+        [
+            signal("a", impact=1.0, need=1.0, urgency=1.0),
+            signal("b", impact=0.5, need=0.5, urgency=0.5),
+        ],
+        policy=policy,
+    )
+
+    assert sum(decision["normalized_recommended_weight"] for decision in decisions) == (
+        pytest.approx(1.0)
+    )
+    assert sum(decision["guarded_recommended_weight"] for decision in decisions) <= (
+        1.0 - policy.exploration_budget + 1e-9
+    )
+
+
+def test_zero_weight_inputs_stay_zero_and_held():
+    decisions = propose_allocations(
+        [
+            signal(
+                "zero-a",
+                impact=0.0,
+                need=0.0,
+                urgency=0.0,
+                neglect=0.0,
+                funding_gap=0.0,
+                absorptive_capacity=0.0,
+            ),
+            signal(
+                "zero-b",
+                impact=0.0,
+                need=0.0,
+                urgency=0.0,
+                neglect=0.0,
+                funding_gap=0.0,
+                absorptive_capacity=0.0,
+            ),
+        ]
+    )
+
+    assert all(decision["guarded_recommended_weight"] == 0.0 for decision in decisions)
+    assert all(decision["normalized_recommended_weight"] == 0.0 for decision in decisions)
+    assert all(decision["hold_transfer"] is True for decision in decisions)
+
+
+def test_portfolio_guard_requires_human_promotion():
+    decisions = propose_allocations(
+        [
+            signal("nets"),
+            signal("food"),
+            signal("education"),
+        ]
+    )
+
+    assert all(decision["hold_transfer"] is True for decision in decisions)
+    assert all(
+        decision["portfolio_guard"]["human_review_required_for_promotion"] is True
+        for decision in decisions
+    )
+    assert all("guarded_recommended_weight" in decision for decision in decisions)


### PR DESCRIPTION
Adds graceful allocation degradation for charity routing.

Core law:
Verified impact bends the gradient.
It does not own the gradient.
No single charity may become the whole definition of good.

Implemented:
- portfolio diversity policy
- max single-charity allocation cap
- reserved exploration budget
- concentration review reasons
- human review required for promotion
- transfer posture remains held

Boundary:
- proposal weights only
- no wallet access
- no transaction signing
- no capital movement
- no autonomous release of funds

Validated:
- dominant charity is capped instead of punished
- exploration budget is preserved
- raw normalized signal remains separate from guarded signal
- zero-weight inputs stay zero and held
- portfolio guard requires human promotion

Principle:
Graceful degradation over chaotic stop.