### PR TITLE
Add Codex organ contract scaffold

### DIFF
--- a/contracts/ORGAN_CONTRACT.md
+++ b/contracts/ORGAN_CONTRACT.md
@@ -1,0 +1,97 @@
+# CodexTradingEngine Organ Contract
+
+CodexTradingEngine is the market-facing metabolic organ of the larger SpiralBloom / Devania constitutional ecosystem.
+
+Its role is to observe markets, simulate candidate actions, emit auditable artifacts, and route proposed value toward verified public benefit. It does not self-promote. It does not independently authorize capital movement. It does not mutate governance state.
+
+## Core Identity
+
+- Organ ID: `codex_trading_engine`
+- Organ type: `market_facing_metabolic_organ`
+- Default mode: `simulation`
+- Contract version: `0.1.0`
+
+## Constitutional Posture
+
+Codex operates under a proposal-only posture.
+
+Core rule:
+
+> Agent proposes. Artifact records. Verifier gates. Registry remembers. Human promotes.
+
+Codex may emit artifacts for review. It may not silently promote those artifacts into execution authority.
+
+## Allowed Outputs
+
+Codex may emit:
+
+- `artifact_receipt`
+- `risk_report`
+- `charity_allocation_proposal`
+- `simulation_summary`
+- `drift_audit`
+- `testnet_result`
+
+These outputs are records, not commands.
+
+## Forbidden Capabilities
+
+Codex may not claim or perform:
+
+- wallet signing
+- autonomous capital movement
+- governance mutation
+- webhook-triggered execution
+- scheduler-triggered execution
+- silent remote command execution
+- self-promotion
+- receipt mutation after emission
+
+## Allowed Modes
+
+Codex may operate in these declared modes:
+
+- `simulation`
+- `historical_replay`
+- `testnet`
+- `shadow_live_market_data`
+- `human_gated_execution`
+- `ttl_bounded_autonomy`
+
+Any movement beyond simulation requires explicit gate progression, review, and human promotion.
+
+## Promotion Path
+
+The valid promotion path is:
+
+1. simulate
+2. validate
+3. emit receipt
+4. ingest receipt
+5. verify
+6. human review
+7. human promotion
+
+No step may silently skip human review or human promotion.
+
+## Hard Invariants
+
+- Codex proposes.
+- Artifacts record.
+- Verifiers gate.
+- Registry remembers.
+- Human promotes.
+- No single charity may become the whole definition of good.
+- Graceful degradation over chaotic stop.
+
+## Bridge Rule
+
+SpiralBloom may review Codex artifacts.
+
+SpiralBloom may not silently command Codex execution.
+
+Codex may emit proposals.
+
+Codex may not mutate SpiralBloom governance state.
+
+The bridge remains artifact-driven, review-first, and human-promoted.

--- a/contracts/organ_contract.json
+++ b/contracts/organ_contract.json
@@ -1,0 +1,56 @@
+{
+  "organ_id": "codex_trading_engine",
+  "organ_type": "market_facing_metabolic_organ",
+  "version": "0.1.0",
+  "default_mode": "simulation",
+  "constitutional_posture": {
+    "proposal_only": true,
+    "human_promotion_required": true,
+    "ttl_required_for_autonomy": true,
+    "no_reverse_execution_channel": true
+  },
+  "allowed_outputs": [
+    "artifact_receipt",
+    "risk_report",
+    "charity_allocation_proposal",
+    "simulation_summary",
+    "drift_audit",
+    "testnet_result"
+  ],
+  "forbidden_capabilities": [
+    "wallet_signing",
+    "autonomous_capital_movement",
+    "governance_mutation",
+    "webhook_triggered_execution",
+    "scheduler_triggered_execution",
+    "silent_remote_command_execution",
+    "self_promotion",
+    "receipt_mutation_after_emission"
+  ],
+  "allowed_modes": [
+    "simulation",
+    "historical_replay",
+    "testnet",
+    "shadow_live_market_data",
+    "human_gated_execution",
+    "ttl_bounded_autonomy"
+  ],
+  "promotion_path": [
+    "simulate",
+    "validate",
+    "emit_receipt",
+    "ingest_receipt",
+    "verify",
+    "human_review",
+    "human_promotion"
+  ],
+  "hard_invariants": [
+    "Codex proposes.",
+    "Artifacts record.",
+    "Verifiers gate.",
+    "Registry remembers.",
+    "Human promotes.",
+    "No single charity may become the whole definition of good.",
+    "Graceful degradation over chaotic stop."
+  ]
+}

--- a/tests/test_organ_contract_scaffold.py
+++ b/tests/test_organ_contract_scaffold.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+CONTRACT_PATH = Path("contracts/organ_contract.json")
+DOC_PATH = Path("contracts/ORGAN_CONTRACT.md")
+
+
+def load_contract():
+    return json.loads(CONTRACT_PATH.read_text())
+
+
+def test_organ_contract_files_exist():
+    assert CONTRACT_PATH.exists()
+    assert DOC_PATH.exists()
+
+
+def test_organ_contract_declares_codex_identity():
+    contract = load_contract()
+
+    assert contract["organ_id"] == "codex_trading_engine"
+    assert contract["organ_type"] == "market_facing_metabolic_organ"
+    assert contract["version"] == "0.1.0"
+    assert contract["default_mode"] == "simulation"
+
+
+def test_organ_contract_requires_proposal_only_human_promotion():
+    posture = load_contract()["constitutional_posture"]
+
+    assert posture["proposal_only"] is True
+    assert posture["human_promotion_required"] is True
+    assert posture["ttl_required_for_autonomy"] is True
+    assert posture["no_reverse_execution_channel"] is True
+
+
+def test_organ_contract_allows_only_artifact_style_outputs():
+    contract = load_contract()
+
+    expected_outputs = {
+        "artifact_receipt",
+        "risk_report",
+        "charity_allocation_proposal",
+        "simulation_summary",
+        "drift_audit",
+        "testnet_result",
+    }
+
+    assert set(contract["allowed_outputs"]) == expected_outputs
+
+
+def test_organ_contract_declares_forbidden_capabilities():
+    contract = load_contract()
+
+    forbidden = set(contract["forbidden_capabilities"])
+
+    assert "wallet_signing" in forbidden
+    assert "autonomous_capital_movement" in forbidden
+    assert "governance_mutation" in forbidden
+    assert "webhook_triggered_execution" in forbidden
+    assert "scheduler_triggered_execution" in forbidden
+    assert "silent_remote_command_execution" in forbidden
+    assert "self_promotion" in forbidden
+    assert "receipt_mutation_after_emission" in forbidden
+
+
+def test_organ_contract_declares_valid_promotion_path():
+    contract = load_contract()
+
+    assert contract["promotion_path"] == [
+        "simulate",
+        "validate",
+        "emit_receipt",
+        "ingest_receipt",
+        "verify",
+        "human_review",
+        "human_promotion",
+    ]
+
+
+def test_organ_contract_preserves_hard_invariants():
+    invariants = set(load_contract()["hard_invariants"])
+
+    assert "Codex proposes." in invariants
+    assert "Artifacts record." in invariants
+    assert "Verifiers gate." in invariants
+    assert "Registry remembers." in invariants
+    assert "Human promotes." in invariants
+    assert "No single charity may become the whole definition of good." in invariants
+    assert "Graceful degradation over chaotic stop." in invariants
+
+
+def test_human_readable_contract_contains_bridge_rule():
+    doc = DOC_PATH.read_text()
+
+    assert "SpiralBloom may review Codex artifacts." in doc
+    assert "SpiralBloom may not silently command Codex execution." in doc
+    assert "Codex may not mutate SpiralBloom governance state." in doc


### PR DESCRIPTION
Adds the CodexTradingEngine organ contract scaffold.

Includes:
- human-readable ORGAN_CONTRACT.md
- machine-readable organ_contract.json
- scaffold regression tests for contract identity, posture, allowed outputs, forbidden capabilities, promotion path, invariants, and bridge rule

Core rule:
Agent proposes. Artifact records. Verifier gates. Registry remembers. Human promotes.

Boundary:
- contract only
- no wallet access
- no transaction signing
- no capital movement
- no autonomous execution
- no reverse execution channel

Purpose:
Establish CodexTradingEngine as a federated market-facing metabolic organ with a local constitutional membrane.