### PR TITLE
Expand CI coverage for constitutional surfaces

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -7,20 +7,20 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'contracts/**'
       - 'tests/test_cross_repo_ingestor.py'
       - 'tests/test_receipt_emitter.py'
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
-      - 'contracts/**'
-      - 'eve_q/allocation/**'
-      - 'eve_q/telemetry/**'
-      - 'tests/test_organ_contract_scaffold.py'
-      - 'tests/test_charity_allocation_diversity_guard.py'
-      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint-and-format.yml'
   pull_request:
     paths:
@@ -28,20 +28,20 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'contracts/**'
       - 'tests/test_cross_repo_ingestor.py'
       - 'tests/test_receipt_emitter.py'
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
-      - 'contracts/**'
-      - 'eve_q/allocation/**'
-      - 'eve_q/telemetry/**'
-      - 'tests/test_organ_contract_scaffold.py'
-      - 'tests/test_charity_allocation_diversity_guard.py'
-      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint-and-format.yml'
 
 jobs:
@@ -68,18 +68,17 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/allocation/charity_router.py \
+            eve_q/allocation/geodesic_policy.py \
+            eve_q/telemetry/impact_score.py \
+            eve_q/telemetry/need_score.py \
             tests/test_cross_repo_ingestor.py \
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
-            eve_q/telemetry/need_score.py \ \
-            eve_q/telemetry/need_score.py \ \
-            eve_q/telemetry/impact_score.py \ \
-            eve_q/telemetry/impact_score.py \ \
-            eve_q/allocation/geodesic_policy.py \ \
-            eve_q/allocation/geodesic_policy.py \ \
-            eve_q/allocation/charity_router.py \ \
-            eve_q/allocation/charity_router.py \
+            tests/test_organ_contract_scaffold.py \
+            tests/test_charity_allocation_diversity_guard.py \
+            tests/test_need_impact_scoring.py
 
       - name: Run flake8 on constitutional scope
         run: |
@@ -88,7 +87,14 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/allocation/charity_router.py \
+            eve_q/allocation/geodesic_policy.py \
+            eve_q/telemetry/impact_score.py \
+            eve_q/telemetry/need_score.py \
             tests/test_cross_repo_ingestor.py \
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
-            tests/test_risk_management.py
+            tests/test_risk_management.py \
+            tests/test_organ_contract_scaffold.py \
+            tests/test_charity_allocation_diversity_guard.py \
+            tests/test_need_impact_scoring.py

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -15,6 +15,12 @@ on:
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
+      - 'contracts/**'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint-and-format.yml'
   pull_request:
     paths:
@@ -30,6 +36,12 @@ on:
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
+      - 'contracts/**'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint-and-format.yml'
 
 jobs:
@@ -49,7 +61,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      - name: Run black on bridge scope
+      - name: Run black on constitutional scope
         run: |
           black --check \
             eve_q/cross_repo_ingestor.py \
@@ -59,9 +71,17 @@ jobs:
             tests/test_cross_repo_ingestor.py \
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
-            tests/test_risk_management.py
+            tests/test_risk_management.py \
+            eve_q/telemetry/need_score.py \ \
+            eve_q/telemetry/need_score.py \ \
+            eve_q/telemetry/impact_score.py \ \
+            eve_q/telemetry/impact_score.py \ \
+            eve_q/allocation/geodesic_policy.py \ \
+            eve_q/allocation/geodesic_policy.py \ \
+            eve_q/allocation/charity_router.py \ \
+            eve_q/allocation/charity_router.py \
 
-      - name: Run flake8 on bridge scope
+      - name: Run flake8 on constitutional scope
         run: |
           flake8 \
             eve_q/cross_repo_ingestor.py \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,20 +7,20 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'contracts/**'
       - 'tests/test_cross_repo_ingestor.py'
       - 'tests/test_receipt_emitter.py'
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
-      - 'contracts/**'
-      - 'eve_q/allocation/**'
-      - 'eve_q/telemetry/**'
-      - 'tests/test_organ_contract_scaffold.py'
-      - 'tests/test_charity_allocation_diversity_guard.py'
-      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint.yml'
   pull_request:
     paths:
@@ -28,20 +28,20 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'contracts/**'
       - 'tests/test_cross_repo_ingestor.py'
       - 'tests/test_receipt_emitter.py'
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
-      - 'contracts/**'
-      - 'eve_q/allocation/**'
-      - 'eve_q/telemetry/**'
-      - 'tests/test_organ_contract_scaffold.py'
-      - 'tests/test_charity_allocation_diversity_guard.py'
-      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint.yml'
 
 jobs:
@@ -68,21 +68,17 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/allocation/charity_router.py \
+            eve_q/allocation/geodesic_policy.py \
+            eve_q/telemetry/impact_score.py \
+            eve_q/telemetry/need_score.py \
             tests/test_cross_repo_ingestor.py \
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
-            tests/test_need_impact_scoring.py \
-            tests/test_charity_allocation_diversity_guard.py \
             tests/test_organ_contract_scaffold.py \
-            eve_q/telemetry/need_score.py \ \
-            eve_q/telemetry/need_score.py \ \
-            eve_q/telemetry/impact_score.py \ \
-            eve_q/telemetry/impact_score.py \ \
-            eve_q/allocation/geodesic_policy.py \ \
-            eve_q/allocation/geodesic_policy.py \ \
-            eve_q/allocation/charity_router.py \ \
-            eve_q/allocation/charity_router.py \
+            tests/test_charity_allocation_diversity_guard.py \
+            tests/test_need_impact_scoring.py
 
       - name: Run flake8 on constitutional scope
         run: |
@@ -91,10 +87,17 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/allocation/charity_router.py \
+            eve_q/allocation/geodesic_policy.py \
+            eve_q/telemetry/impact_score.py \
+            eve_q/telemetry/need_score.py \
             tests/test_cross_repo_ingestor.py \
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
-            tests/test_risk_management.py
+            tests/test_risk_management.py \
+            tests/test_organ_contract_scaffold.py \
+            tests/test_charity_allocation_diversity_guard.py \
+            tests/test_need_impact_scoring.py
 
       - name: Run constitutional tests
         run: |
@@ -103,7 +106,7 @@ jobs:
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
-            tests/test_need_impact_scoring.py \
-            tests/test_charity_allocation_diversity_guard.py \
             tests/test_organ_contract_scaffold.py \
+            tests/test_charity_allocation_diversity_guard.py \
+            tests/test_need_impact_scoring.py \
             -q

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,12 @@ on:
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
+      - 'contracts/**'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint.yml'
   pull_request:
     paths:
@@ -30,6 +36,12 @@ on:
       - 'requirements-dev.txt'
       - 'pyproject.toml'
       - '.flake8'
+      - 'contracts/**'
+      - 'eve_q/allocation/**'
+      - 'eve_q/telemetry/**'
+      - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_charity_allocation_diversity_guard.py'
+      - 'tests/test_need_impact_scoring.py'
       - '.github/workflows/lint.yml'
 
 jobs:
@@ -49,7 +61,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      - name: Run black on bridge scope
+      - name: Run black on constitutional scope
         run: |
           black --check \
             eve_q/cross_repo_ingestor.py \
@@ -59,9 +71,20 @@ jobs:
             tests/test_cross_repo_ingestor.py \
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
-            tests/test_risk_management.py
+            tests/test_risk_management.py \
+            tests/test_need_impact_scoring.py \
+            tests/test_charity_allocation_diversity_guard.py \
+            tests/test_organ_contract_scaffold.py \
+            eve_q/telemetry/need_score.py \ \
+            eve_q/telemetry/need_score.py \ \
+            eve_q/telemetry/impact_score.py \ \
+            eve_q/telemetry/impact_score.py \ \
+            eve_q/allocation/geodesic_policy.py \ \
+            eve_q/allocation/geodesic_policy.py \ \
+            eve_q/allocation/charity_router.py \ \
+            eve_q/allocation/charity_router.py \
 
-      - name: Run flake8 on bridge scope
+      - name: Run flake8 on constitutional scope
         run: |
           flake8 \
             eve_q/cross_repo_ingestor.py \
@@ -73,11 +96,14 @@ jobs:
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py
 
-      - name: Run bridge tests
+      - name: Run constitutional tests
         run: |
           pytest -o addopts='' \
             tests/test_cross_repo_ingestor.py \
             tests/test_receipt_emitter.py \
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
+            tests/test_need_impact_scoring.py \
+            tests/test_charity_allocation_diversity_guard.py \
+            tests/test_organ_contract_scaffold.py \
             -q


### PR DESCRIPTION
Expands GitHub Actions coverage for constitutional surfaces.

Adds CI path coverage for:
- `contracts/**`
- `eve_q/allocation/**`
- `eve_q/telemetry/**`
- organ contract scaffold tests
- charity allocation diversity guard tests
- need/impact scoring tests

Updates black, flake8, and pytest targets so contract, allocation, and telemetry surfaces are tested by automation.

Boundary:
- CI only
- no runtime behavior changes

Principle:
Guard the guard. The repo must remember to test the membranes that constrain it.

Closes #12.