### PR TITLE
Enforce organ contract for receipt emission

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -7,6 +7,7 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/organ_contract.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -15,6 +16,7 @@ on:
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -28,6 +30,7 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/organ_contract.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -36,6 +39,7 @@ on:
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -68,6 +72,7 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/organ_contract.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -77,6 +82,7 @@ jobs:
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
+            tests/test_organ_contract_enforcement.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -87,6 +93,7 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/organ_contract.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -96,5 +103,6 @@ jobs:
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
+            tests/test_organ_contract_enforcement.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/organ_contract.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -15,6 +16,7 @@ on:
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -28,6 +30,7 @@ on:
       - 'eve_q/receipt_emitter.py'
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
+      - 'eve_q/organ_contract.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -36,6 +39,7 @@ on:
       - 'tests/test_alert_dispatcher.py'
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
+      - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -68,6 +72,7 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/organ_contract.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -77,6 +82,7 @@ jobs:
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
+            tests/test_organ_contract_enforcement.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -87,6 +93,7 @@ jobs:
             eve_q/receipt_emitter.py \
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
+            eve_q/organ_contract.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -96,6 +103,7 @@ jobs:
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
+            tests/test_organ_contract_enforcement.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -107,6 +115,7 @@ jobs:
             tests/test_alert_dispatcher.py \
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
+            tests/test_organ_contract_enforcement.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py \
             -q

--- a/contracts/organ_contract.json
+++ b/contracts/organ_contract.json
@@ -11,6 +11,7 @@
   },
   "allowed_outputs": [
     "artifact_receipt",
+    "safety_bridge_receipt",
     "risk_report",
     "charity_allocation_proposal",
     "simulation_summary",
@@ -28,6 +29,7 @@
     "receipt_mutation_after_emission"
   ],
   "allowed_modes": [
+    "artifact_only",
     "simulation",
     "historical_replay",
     "testnet",

--- a/eve_q/organ_contract.py
+++ b/eve_q/organ_contract.py
@@ -1,0 +1,163 @@
+"""Organ contract validation for CodexTradingEngine.
+
+The organ contract is the local constitutional membrane. It defines what
+Codex may emit and what it must never claim while producing artifacts.
+
+This module validates records only. It does not execute, schedule, sign,
+transfer, promote, or mutate governance state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONTRACT_PATH = REPO_ROOT / "contracts" / "organ_contract.json"
+
+CONTRACT_REQUIRED_FIELDS = {
+    "organ_id",
+    "organ_type",
+    "version",
+    "default_mode",
+    "constitutional_posture",
+    "allowed_outputs",
+    "forbidden_capabilities",
+    "allowed_modes",
+    "promotion_path",
+    "hard_invariants",
+}
+
+ACTION_INTENT_FIELDS = {
+    "action",
+    "requested_action",
+    "intent",
+    "operation",
+    "execution",
+    "next_action",
+    "automation",
+    "scheduler",
+    "webhook",
+    "silent_remote_command_execution",
+    "self_promotion",
+    "governance_mutation",
+}
+
+CAPABILITY_FIELDS = {
+    "capability",
+    "capabilities",
+    "claimed_capability",
+    "claimed_capabilities",
+}
+
+
+def load_organ_contract(path: str | Path = DEFAULT_CONTRACT_PATH) -> dict[str, Any]:
+    """Load the machine-readable organ contract."""
+
+    contract_path = Path(path)
+    return json.loads(contract_path.read_text(encoding="utf-8"))
+
+
+def validate_contract_shape(contract: dict[str, Any]) -> list[str]:
+    """Validate the contract document itself."""
+
+    errors: list[str] = []
+
+    missing = sorted(CONTRACT_REQUIRED_FIELDS - set(contract))
+    if missing:
+        errors.append(f"contract missing required fields: {', '.join(missing)}")
+
+    posture = contract.get("constitutional_posture", {})
+    if not isinstance(posture, dict):
+        errors.append("constitutional_posture must be an object")
+        return errors
+
+    required_true_posture = {
+        "proposal_only",
+        "human_promotion_required",
+        "ttl_required_for_autonomy",
+        "no_reverse_execution_channel",
+    }
+    for field in sorted(required_true_posture):
+        if posture.get(field) is not True:
+            errors.append(f"constitutional_posture.{field} must be true")
+
+    for list_field in [
+        "allowed_outputs",
+        "forbidden_capabilities",
+        "allowed_modes",
+        "promotion_path",
+        "hard_invariants",
+    ]:
+        if list_field in contract and not isinstance(contract[list_field], list):
+            errors.append(f"{list_field} must be a list")
+
+    return errors
+
+
+def _as_string_set(value: Any) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, (list, tuple, set)):
+        return {str(item) for item in value}
+    return {str(value)}
+
+
+def validate_receipt_against_contract(
+    receipt: dict[str, Any],
+    *,
+    contract: dict[str, Any] | None = None,
+    contract_path: str | Path = DEFAULT_CONTRACT_PATH,
+) -> list[str]:
+    """Validate a receipt against the organ contract."""
+
+    errors: list[str] = []
+    active_contract = contract or load_organ_contract(contract_path)
+
+    errors.extend(validate_contract_shape(active_contract))
+
+    allowed_outputs = set(active_contract.get("allowed_outputs", []))
+    artifact_type = receipt.get("artifact_type")
+    if artifact_type not in allowed_outputs:
+        errors.append("artifact_type is not allowed by organ contract: " f"{artifact_type!r}")
+
+    allowed_modes = set(active_contract.get("allowed_modes", []))
+    mode = receipt.get("mode")
+    if mode not in allowed_modes:
+        errors.append(f"mode is not allowed by organ contract: {mode!r}")
+
+    posture = active_contract.get("constitutional_posture", {})
+    if posture.get("human_promotion_required") is True:
+        if receipt.get("human_promotion_required") is not True:
+            errors.append("human_promotion_required must be true by organ contract")
+
+    forbidden_action_fields = sorted(ACTION_INTENT_FIELDS & set(receipt))
+    if forbidden_action_fields:
+        errors.append(
+            "receipt must not contain action/execution fields: "
+            + ", ".join(forbidden_action_fields)
+        )
+
+    forbidden_capabilities = set(active_contract.get("forbidden_capabilities", []))
+    forbidden_direct_keys = sorted(forbidden_capabilities & set(receipt))
+    if forbidden_direct_keys:
+        errors.append(
+            "receipt must not claim forbidden capabilities as fields: "
+            + ", ".join(forbidden_direct_keys)
+        )
+
+    claimed_capabilities: set[str] = set()
+    for field in CAPABILITY_FIELDS:
+        if field in receipt:
+            claimed_capabilities |= _as_string_set(receipt[field])
+
+    forbidden_claims = sorted(forbidden_capabilities & claimed_capabilities)
+    if forbidden_claims:
+        errors.append(
+            "receipt must not claim forbidden capabilities: " + ", ".join(forbidden_claims)
+        )
+
+    return errors

--- a/eve_q/receipt_emitter.py
+++ b/eve_q/receipt_emitter.py
@@ -19,6 +19,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+try:
+    from eve_q.organ_contract import validate_receipt_against_contract
+except ModuleNotFoundError:  # Allows direct script execution from eve_q/.
+    from organ_contract import validate_receipt_against_contract
+
 SPIRALBLOOM_REQUIRED_FIELDS = {
     "source_repo",
     "source_commit",
@@ -156,6 +161,8 @@ def validate_emitted_receipt(receipt: dict[str, Any]) -> list[str]:
         errors.append(
             "receipt must not contain action/intent fields: " + ", ".join(forbidden_present)
         )
+
+    errors.extend(validate_receipt_against_contract(receipt))
 
     return errors
 

--- a/tests/test_organ_contract_enforcement.py
+++ b/tests/test_organ_contract_enforcement.py
@@ -1,0 +1,109 @@
+from copy import deepcopy
+
+from eve_q.organ_contract import (
+    load_organ_contract,
+    validate_contract_shape,
+    validate_receipt_against_contract,
+)
+from eve_q.receipt_emitter import build_receipt, validate_emitted_receipt
+
+VALID_SHA = "a" * 64
+
+
+def minimal_receipt(**overrides):
+    receipt = {
+        "source_repo": "ArchitectofAthena/CodexTradingEngine",
+        "source_commit": "abc123",
+        "artifact_type": "safety_bridge_receipt",
+        "artifact_path": "artifacts/example.json",
+        "artifact_sha256": VALID_SHA,
+        "mode": "artifact_only",
+        "summary": "Artifact-only receipt.",
+        "boundary": ["human promotion required"],
+        "human_promotion_required": True,
+    }
+    receipt.update(overrides)
+    return receipt
+
+
+def test_organ_contract_shape_is_valid():
+    contract = load_organ_contract()
+
+    assert validate_contract_shape(contract) == []
+
+
+def test_default_receipt_shape_is_allowed_by_organ_contract(tmp_path):
+    artifact = tmp_path / "artifact.json"
+    artifact.write_text('{"ok": true}\n')
+
+    receipt = build_receipt(
+        artifact_path=artifact,
+        source_repo="ArchitectofAthena/CodexTradingEngine",
+        source_commit="abc123",
+        root=tmp_path,
+    )
+
+    assert validate_receipt_against_contract(receipt) == []
+    assert validate_emitted_receipt(receipt) == []
+
+
+def test_undeclared_artifact_type_is_rejected():
+    receipt = minimal_receipt(artifact_type="undeclared_output")
+
+    errors = validate_receipt_against_contract(receipt)
+
+    assert any("artifact_type is not allowed" in error for error in errors)
+
+
+def test_mode_outside_contract_is_rejected():
+    receipt = minimal_receipt(mode="rogue_mode")
+
+    errors = validate_receipt_against_contract(receipt)
+
+    assert any("mode is not allowed" in error for error in errors)
+
+
+def test_human_promotion_required_by_contract():
+    receipt = minimal_receipt(human_promotion_required=False)
+
+    errors = validate_receipt_against_contract(receipt)
+
+    assert any("human_promotion_required must be true" in error for error in errors)
+
+
+def test_action_execution_fields_are_rejected():
+    receipt = minimal_receipt(webhook="https://example.invalid/hook")
+
+    errors = validate_receipt_against_contract(receipt)
+
+    assert any("action/execution fields" in error for error in errors)
+
+
+def test_forbidden_capability_direct_field_is_rejected():
+    receipt = minimal_receipt(wallet_signing=True)
+
+    errors = validate_receipt_against_contract(receipt)
+
+    assert any("forbidden capabilities as fields" in error for error in errors)
+
+
+def test_forbidden_capability_claim_is_rejected():
+    receipt = minimal_receipt(claimed_capabilities=["wallet_signing"])
+
+    errors = validate_receipt_against_contract(receipt)
+
+    assert any("forbidden capabilities" in error for error in errors)
+
+
+def test_contract_can_detect_contract_shape_drift():
+    contract = deepcopy(load_organ_contract())
+    contract["constitutional_posture"]["human_promotion_required"] = False
+
+    errors = validate_receipt_against_contract(
+        minimal_receipt(),
+        contract=contract,
+    )
+
+    assert any(
+        "constitutional_posture.human_promotion_required must be true" in error for error in errors
+    )

--- a/tests/test_organ_contract_scaffold.py
+++ b/tests/test_organ_contract_scaffold.py
@@ -37,6 +37,7 @@ def test_organ_contract_allows_only_artifact_style_outputs():
 
     expected_outputs = {
         "artifact_receipt",
+        "safety_bridge_receipt",
         "risk_report",
         "charity_allocation_proposal",
         "simulation_summary",


### PR DESCRIPTION
Turns the Codex organ contract from scaffold into an active local membrane for receipt emission.

Implemented:
- organ contract loader and validator
- receipt validation against contracts/organ_contract.json
- safety_bridge_receipt added as an allowed output for backward compatibility
- artifact_only added as an allowed receipt emission mode
- enforcement tests for allowed outputs, forbidden capabilities, action/execution fields, allowed modes, human promotion, and contract drift
- CI coverage expanded to include organ contract enforcement

Validated locally:
- black --check passed on constitutional scope
- flake8 passed on constitutional scope
- scoped pytest passed: 40 passed
- organ_contract.json validates as JSON

Boundary:
- validation only
- no wallet access
- no transaction signing
- no capital movement
- no autonomous execution
- no reverse execution channel

Principle:
Contract becomes membrane. Artifact stays record, not command.

Closes #13.