### PR TITLE
Add TTL graceful degradation policy

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -17,6 +17,7 @@ on:
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
+      - 'tests/test_ttl_policy_scaffold.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -40,6 +41,7 @@ on:
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
+      - 'tests/test_ttl_policy_scaffold.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -83,6 +85,7 @@ jobs:
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
+            tests/test_ttl_policy_scaffold.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -104,5 +107,6 @@ jobs:
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
+            tests/test_ttl_policy_scaffold.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ on:
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
+      - 'tests/test_ttl_policy_scaffold.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -40,6 +41,7 @@ on:
       - 'tests/test_risk_management.py'
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
+      - 'tests/test_ttl_policy_scaffold.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -83,6 +85,7 @@ jobs:
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
+            tests/test_ttl_policy_scaffold.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -104,6 +107,7 @@ jobs:
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
+            tests/test_ttl_policy_scaffold.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -116,6 +120,7 @@ jobs:
             tests/test_risk_management.py \
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
+            tests/test_ttl_policy_scaffold.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py \
             -q

--- a/SAFETY.md
+++ b/SAFETY.md
@@ -1,0 +1,58 @@
+# Safety Boundary
+
+CodexTradingEngine is a simulation-first, artifact-first safety research repository.
+
+## Repository Boundary
+
+This repository may define:
+
+- policies
+- simulations
+- receipts
+- risk reports
+- drift audits
+- charity allocation proposals
+- testnet results
+- validation artifacts
+
+This repository must not silently perform:
+
+- wallet signing
+- transaction signing
+- capital movement
+- autonomous execution
+- webhook-triggered execution
+- scheduler-triggered execution
+- governance mutation
+- self-promotion
+- reverse execution into SpiralBloom OS
+
+## Authority Model
+
+Agent proposes. Artifact records. Verifier gates. Registry remembers. Human promotes.
+
+Authority expires. Uncertainty degrades permission. Human approval renews authority.
+
+## SpiralBloom Bridge
+
+SpiralBloom may review Codex artifacts.
+
+Codex may emit proposals.
+
+Codex may not silently command SpiralBloom execution.
+
+SpiralBloom may not silently command Codex execution.
+
+The bridge is artifact-driven, review-first, and human-promoted.
+
+## Runtime Boundary
+
+Policy artifacts in this repository do not create runtime authority.
+
+A policy file is not permission to trade.
+
+A receipt is not permission to execute.
+
+A passing test is not permission to move capital.
+
+Human approval remains required for any real capital touchpoint.

--- a/contracts/ttl_policy.json
+++ b/contracts/ttl_policy.json
@@ -1,0 +1,115 @@
+{
+  "policy_id": "ttl_graceful_degradation_policy",
+  "version": "0.1.0",
+  "posture": {
+    "authority_expires": true,
+    "uncertainty_degrades_permission": true,
+    "graceful_degradation_preferred": true,
+    "hard_stop_on_forbidden_capability": true,
+    "human_approval_required_for_renewal": true
+  },
+  "authority_rank": {
+    "artifact_only": 0,
+    "simulation": 0,
+    "historical_replay": 0,
+    "testnet": 1,
+    "shadow_live_market_data": 1,
+    "human_gated_execution": 2,
+    "ttl_bounded_autonomy": 3
+  },
+  "modes": {
+    "artifact_only": {
+      "ttl_required": false,
+      "max_ttl_minutes": null,
+      "degradation_target": "artifact_only"
+    },
+    "simulation": {
+      "ttl_required": false,
+      "max_ttl_minutes": null,
+      "degradation_target": "simulation"
+    },
+    "historical_replay": {
+      "ttl_required": false,
+      "max_ttl_minutes": null,
+      "degradation_target": "simulation"
+    },
+    "testnet": {
+      "ttl_required": true,
+      "max_ttl_minutes": 240,
+      "degradation_target": "simulation"
+    },
+    "shadow_live_market_data": {
+      "ttl_required": true,
+      "max_ttl_minutes": 60,
+      "degradation_target": "simulation"
+    },
+    "human_gated_execution": {
+      "ttl_required": true,
+      "max_ttl_minutes": 30,
+      "degradation_target": "shadow_live_market_data"
+    },
+    "ttl_bounded_autonomy": {
+      "ttl_required": true,
+      "max_ttl_minutes": 15,
+      "degradation_target": "human_gated_execution"
+    }
+  },
+  "ttl_shortening_signals": [
+    "telemetry_staleness",
+    "oracle_staleness",
+    "market_volatility_spike",
+    "failed_validation",
+    "high_anomaly_score",
+    "degraded_data_quality",
+    "missing_human_liveness",
+    "contract_drift_detected",
+    "policy_version_mismatch",
+    "charity_verification_uncertainty",
+    "incomplete_receipt_proof"
+  ],
+  "graceful_degradation_triggers": [
+    "ttl_expired",
+    "human_liveness_absent",
+    "telemetry_stale",
+    "receipt_proof_incomplete",
+    "impact_verification_pending",
+    "model_confidence_below_threshold",
+    "policy_uncertainty_rising",
+    "simulation_replay_divergence"
+  ],
+  "hard_stop_triggers": [
+    "wallet_signing",
+    "autonomous_capital_movement",
+    "governance_mutation",
+    "webhook_triggered_execution",
+    "scheduler_triggered_execution",
+    "silent_remote_command_execution",
+    "self_promotion",
+    "receipt_mutation_after_emission"
+  ],
+  "human_approval_required_for": [
+    "ttl_renewal_after_expiry",
+    "simulation_to_testnet_promotion",
+    "testnet_to_human_gated_execution_promotion",
+    "human_gated_execution_to_ttl_bounded_autonomy_promotion",
+    "any_capital_touchpoint",
+    "charity_allocation_policy_change",
+    "contract_or_ttl_policy_change",
+    "hard_stop_recovery"
+  ],
+  "safe_outputs_after_degradation": [
+    "artifact_receipt",
+    "safety_bridge_receipt",
+    "risk_report",
+    "simulation_summary",
+    "drift_audit"
+  ],
+  "hard_invariants": [
+    "Authority expires.",
+    "Uncertainty degrades permission.",
+    "Expired TTL cannot silently renew itself.",
+    "Graceful degradation is preferred over chaotic stop.",
+    "Hard boundaries stop immediately.",
+    "Human approval renews authority."
+  ]
+}

--- a/docs/ttl_graceful_degradation_policy.md
+++ b/docs/ttl_graceful_degradation_policy.md
@@ -1,0 +1,107 @@
+# TTL and Graceful Degradation Policy
+
+## Purpose
+
+This policy defines how authority expires inside CodexTradingEngine.
+
+Codex may propose, simulate, validate, and emit artifacts. Authority to move into
+higher-risk modes must be time-bounded, human-promoted, and reversible into safer
+states.
+
+Core law:
+
+> Authority expires. Uncertainty degrades permission. Degradation reduces autonomy,
+> confidence, and priority. It does not produce chaotic stop unless a hard boundary
+> is crossed.
+
+## Operating Principles
+
+1. **TTL is not trust.** TTL is a temporary permission window.
+2. **Expired TTL degrades authority.** It does not silently extend itself.
+3. **Uncertainty shortens TTL.** Bad data, stale telemetry, drift, and failed
+   validation reduce permission.
+4. **Hard boundaries stop immediately.** Wallet signing, autonomous capital
+   movement, reverse execution channels, webhook execution, scheduler execution,
+   governance mutation, or self-promotion attempts are hard-stop events.
+5. **Graceful degradation is preferred.** When uncertainty rises without a hard
+   boundary crossing, Codex should fall back to safer modes such as simulation,
+   historical replay, risk report, or drift audit.
+6. **Human promotion renews authority.** Higher modes require explicit renewed
+   approval after expiry or degradation.
+
+## Mode Policy
+
+| Mode | TTL Required | Degradation Target |
+|---|---:|---|
+| artifact_only | No | artifact_only |
+| simulation | No | simulation |
+| historical_replay | No | simulation |
+| testnet | Yes | simulation |
+| shadow_live_market_data | Yes | simulation |
+| human_gated_execution | Yes | shadow_live_market_data |
+| ttl_bounded_autonomy | Yes | human_gated_execution |
+
+## TTL Shortening Signals
+
+TTL should be shortened when any of these signals appear:
+
+- telemetry staleness
+- oracle staleness
+- market volatility spike
+- failed validation
+- high anomaly score
+- degraded data quality
+- missing human liveness
+- contract drift detected
+- policy version mismatch
+- charity verification uncertainty
+- incomplete receipt proof
+
+## Graceful Degradation Triggers
+
+Codex should degrade to a safer mode when:
+
+- TTL expires
+- human liveness is absent
+- telemetry becomes stale
+- receipt proof is incomplete
+- charity or impact verification is pending
+- model confidence drops below threshold
+- policy uncertainty rises
+- simulation/replay diverges from expectation
+
+## Hard Stop Triggers
+
+Codex must hard-stop if any receipt, artifact, process, or proposed behavior claims:
+
+- wallet signing
+- autonomous capital movement
+- governance mutation
+- webhook-triggered execution
+- scheduler-triggered execution
+- silent remote command execution
+- self-promotion
+- receipt mutation after emission
+
+A hard stop should emit only a safe artifact such as a risk report or drift audit.
+It must not create a reverse execution channel.
+
+## Human Approval Required
+
+Renewed human approval is required for:
+
+- TTL renewal after expiry
+- promotion from simulation to testnet
+- promotion from testnet to human-gated execution
+- promotion from human-gated execution to TTL-bounded autonomy
+- any capital touchpoint
+- any charity allocation policy change
+- any contract or TTL policy change
+- any recovery from hard stop
+
+## Summary
+
+Agent proposes. Artifact records. Verifier gates. Registry remembers. Human promotes.
+
+The system should degrade like a living organism protecting itself, not collapse
+like a brittle switch.

--- a/docs/ttl_graceful_degradation_policy.md
+++ b/docs/ttl_graceful_degradation_policy.md
@@ -1,5 +1,7 @@
 # TTL and Graceful Degradation Policy
 
+Version: 0.1.0
+
 ## Purpose
 
 This policy defines how authority expires inside CodexTradingEngine.
@@ -98,6 +100,31 @@ Renewed human approval is required for:
 - any charity allocation policy change
 - any contract or TTL policy change
 - any recovery from hard stop
+
+## Verification Boundary
+
+v0.1.0 is a structural policy scaffold.
+
+It verifies:
+
+- mode coverage
+- TTL-required mode classification
+- degradation rank monotonicity
+- hard-stop trigger declaration
+- human approval declaration
+- JSON/prose alignment for hard-stop triggers
+
+It does not yet implement or prove runtime TTL behavior.
+
+Behavioral firing tests still need to land before any mode above simulation gets
+a real clock. Those future tests must prove:
+
+- an expired TTL degrades to its declared degradation target
+- a hard-stop trigger emits only safe artifacts
+- a hard-stop trigger does not open a reverse execution channel
+- a TTL-shortening signal actually shortens the active window
+
+Membrane before motion.
 
 ## Summary
 

--- a/tests/test_ttl_policy_scaffold.py
+++ b/tests/test_ttl_policy_scaffold.py
@@ -1,0 +1,84 @@
+import json
+from pathlib import Path
+
+TTL_POLICY_PATH = Path("contracts/ttl_policy.json")
+TTL_DOC_PATH = Path("docs/ttl_graceful_degradation_policy.md")
+ORGAN_CONTRACT_PATH = Path("contracts/organ_contract.json")
+
+
+def load_ttl_policy():
+    return json.loads(TTL_POLICY_PATH.read_text())
+
+
+def load_organ_contract():
+    return json.loads(ORGAN_CONTRACT_PATH.read_text())
+
+
+def test_ttl_policy_files_exist():
+    assert TTL_POLICY_PATH.exists()
+    assert TTL_DOC_PATH.exists()
+
+
+def test_ttl_policy_declares_expiring_authority_posture():
+    posture = load_ttl_policy()["posture"]
+
+    assert posture["authority_expires"] is True
+    assert posture["uncertainty_degrades_permission"] is True
+    assert posture["graceful_degradation_preferred"] is True
+    assert posture["hard_stop_on_forbidden_capability"] is True
+    assert posture["human_approval_required_for_renewal"] is True
+
+
+def test_ttl_policy_covers_all_organ_contract_modes():
+    ttl_modes = set(load_ttl_policy()["modes"])
+    organ_modes = set(load_organ_contract()["allowed_modes"])
+
+    assert ttl_modes == organ_modes
+
+
+def test_higher_authority_modes_require_ttl():
+    modes = load_ttl_policy()["modes"]
+
+    assert modes["artifact_only"]["ttl_required"] is False
+    assert modes["simulation"]["ttl_required"] is False
+    assert modes["historical_replay"]["ttl_required"] is False
+    assert modes["testnet"]["ttl_required"] is True
+    assert modes["shadow_live_market_data"]["ttl_required"] is True
+    assert modes["human_gated_execution"]["ttl_required"] is True
+    assert modes["ttl_bounded_autonomy"]["ttl_required"] is True
+
+
+def test_degradation_never_increases_authority():
+    policy = load_ttl_policy()
+    ranks = policy["authority_rank"]
+
+    for mode, mode_policy in policy["modes"].items():
+        target = mode_policy["degradation_target"]
+        assert target in ranks
+        assert ranks[target] <= ranks[mode]
+
+
+def test_hard_stop_triggers_cover_forbidden_capabilities():
+    policy = load_ttl_policy()
+    organ_contract = load_organ_contract()
+
+    assert set(organ_contract["forbidden_capabilities"]).issubset(set(policy["hard_stop_triggers"]))
+
+
+def test_human_approval_is_required_for_renewal_and_promotion():
+    required = set(load_ttl_policy()["human_approval_required_for"])
+
+    assert "ttl_renewal_after_expiry" in required
+    assert "simulation_to_testnet_promotion" in required
+    assert "testnet_to_human_gated_execution_promotion" in required
+    assert "human_gated_execution_to_ttl_bounded_autonomy_promotion" in required
+    assert "hard_stop_recovery" in required
+
+
+def test_policy_doc_preserves_core_law():
+    doc = TTL_DOC_PATH.read_text()
+
+    assert "Authority expires." in doc
+    assert "Uncertainty degrades permission." in doc
+    assert "Graceful degradation is preferred" in doc
+    assert "Agent proposes. Artifact records." in doc

--- a/tests/test_ttl_policy_scaffold.py
+++ b/tests/test_ttl_policy_scaffold.py
@@ -82,3 +82,50 @@ def test_policy_doc_preserves_core_law():
     assert "Uncertainty degrades permission." in doc
     assert "Graceful degradation is preferred" in doc
     assert "Agent proposes. Artifact records." in doc
+
+
+EXPECTED_HARD_STOP_TRIGGERS = {
+    "wallet_signing",
+    "autonomous_capital_movement",
+    "governance_mutation",
+    "webhook_triggered_execution",
+    "scheduler_triggered_execution",
+    "silent_remote_command_execution",
+    "self_promotion",
+    "receipt_mutation_after_emission",
+}
+
+
+def normalize_hard_stop_bullet(text):
+    return text.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def hard_stop_bullets_from_doc():
+    doc = TTL_DOC_PATH.read_text()
+    section = doc.split("## Hard Stop Triggers", 1)[1]
+    section = section.split("## Human Approval Required", 1)[0]
+
+    bullets = []
+    for line in section.splitlines():
+        if line.startswith("- "):
+            bullets.append(normalize_hard_stop_bullet(line[2:]))
+
+    return set(bullets)
+
+
+def test_hard_stop_triggers_match_single_declared_canon():
+    policy = load_ttl_policy()
+    organ_contract = load_organ_contract()
+
+    assert set(policy["hard_stop_triggers"]) == EXPECTED_HARD_STOP_TRIGGERS
+    assert set(organ_contract["forbidden_capabilities"]) == EXPECTED_HARD_STOP_TRIGGERS
+    assert hard_stop_bullets_from_doc() == EXPECTED_HARD_STOP_TRIGGERS
+
+
+def test_policy_doc_declares_structural_verification_boundary():
+    doc = TTL_DOC_PATH.read_text()
+
+    assert "Version: 0.1.0" in doc
+    assert "v0.1.0 is a structural policy scaffold." in doc
+    assert "It does not yet implement or prove runtime TTL behavior." in doc
+    assert "Membrane before motion." in doc


### PR DESCRIPTION
Adds a policy scaffold for time-bounded authority and graceful degradation.

Implemented:
- SAFETY.md repository front door
- docs/ttl_graceful_degradation_policy.md
- contracts/ttl_policy.json
- TTL policy scaffold tests
- CI coverage for the TTL policy contract, docs, and tests

Policy covers:
- modes that require TTL
- TTL shortening signals
- graceful degradation triggers
- hard stop triggers
- human approval requirements
- safe outputs after degradation
- authority rank checks to ensure degradation never increases authority

Strengthened in review:
- JSON/prose hard-stop trigger canon audit
- organ contract forbidden capability equality check
- explicit v0.1.0 structural verification boundary
- documented that runtime TTL behavior is not yet implemented or proven
- front-door quarantine file for the whole repository

Validated locally:
- black --check passed on constitutional scope
- flake8 passed on constitutional scope
- scoped pytest passed
- organ_contract.json validates as JSON
- ttl_policy.json validates as JSON

Boundary:
- policy/scaffold only
- no runtime execution changes
- no wallet access
- no transaction signing
- no capital movement
- no autonomous execution

Principle:
Authority expires. Uncertainty degrades permission. Human approval renews authority.

Closes #14.