### PR TITLE
Add pure TTL policy evaluator

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -8,6 +8,7 @@ on:
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
       - 'eve_q/organ_contract.py'
+      - 'eve_q/ttl_policy.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -18,6 +19,7 @@ on:
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_ttl_policy_scaffold.py'
+      - 'tests/test_ttl_policy_evaluator.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -32,6 +34,7 @@ on:
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
       - 'eve_q/organ_contract.py'
+      - 'eve_q/ttl_policy.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -42,6 +45,7 @@ on:
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_ttl_policy_scaffold.py'
+      - 'tests/test_ttl_policy_evaluator.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -75,6 +79,7 @@ jobs:
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
             eve_q/organ_contract.py \
+          eve_q/ttl_policy.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -86,6 +91,7 @@ jobs:
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
             tests/test_ttl_policy_scaffold.py \
+          tests/test_ttl_policy_evaluator.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -97,6 +103,7 @@ jobs:
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
             eve_q/organ_contract.py \
+          eve_q/ttl_policy.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -108,5 +115,6 @@ jobs:
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
             tests/test_ttl_policy_scaffold.py \
+          tests/test_ttl_policy_evaluator.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
       - 'eve_q/organ_contract.py'
+      - 'eve_q/ttl_policy.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -18,6 +19,7 @@ on:
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_ttl_policy_scaffold.py'
+      - 'tests/test_ttl_policy_evaluator.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -32,6 +34,7 @@ on:
       - 'eve_q/alert_dispatcher.py'
       - 'eve_q/risk_management.py'
       - 'eve_q/organ_contract.py'
+      - 'eve_q/ttl_policy.py'
       - 'eve_q/allocation/**'
       - 'eve_q/telemetry/**'
       - 'contracts/**'
@@ -42,6 +45,7 @@ on:
       - 'tests/test_organ_contract_scaffold.py'
       - 'tests/test_organ_contract_enforcement.py'
       - 'tests/test_ttl_policy_scaffold.py'
+      - 'tests/test_ttl_policy_evaluator.py'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -75,6 +79,7 @@ jobs:
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
             eve_q/organ_contract.py \
+          eve_q/ttl_policy.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -86,6 +91,7 @@ jobs:
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
             tests/test_ttl_policy_scaffold.py \
+          tests/test_ttl_policy_evaluator.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -97,6 +103,7 @@ jobs:
             eve_q/alert_dispatcher.py \
             eve_q/risk_management.py \
             eve_q/organ_contract.py \
+          eve_q/ttl_policy.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
             eve_q/telemetry/impact_score.py \
@@ -108,6 +115,7 @@ jobs:
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
             tests/test_ttl_policy_scaffold.py \
+          tests/test_ttl_policy_evaluator.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 
@@ -121,6 +129,7 @@ jobs:
             tests/test_organ_contract_scaffold.py \
             tests/test_organ_contract_enforcement.py \
             tests/test_ttl_policy_scaffold.py \
+          tests/test_ttl_policy_evaluator.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py \
             -q

--- a/eve_q/ttl_policy.py
+++ b/eve_q/ttl_policy.py
@@ -1,0 +1,245 @@
+"""Pure TTL policy evaluator for CodexTradingEngine.
+
+This module evaluates declared TTL policy state. It does not schedule work,
+touch wallets, open network connections, or grant runtime authority.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TTL_POLICY_PATH = REPO_ROOT / "contracts" / "ttl_policy.json"
+
+
+def load_ttl_policy(path: Path | str = DEFAULT_TTL_POLICY_PATH) -> dict[str, Any]:
+    """Load the machine-readable TTL policy."""
+    return json.loads(Path(path).read_text())
+
+
+def _as_string_set(value: Any) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {value}
+    return {str(item) for item in value}
+
+
+def validate_ttl_policy_shape(policy: dict[str, Any]) -> list[str]:
+    """Return structural policy errors without mutating policy."""
+    errors: list[str] = []
+
+    required_fields = {
+        "policy_id",
+        "version",
+        "posture",
+        "authority_rank",
+        "modes",
+        "ttl_shortening_signals",
+        "graceful_degradation_triggers",
+        "hard_stop_triggers",
+        "human_approval_required_for",
+        "safe_outputs_after_degradation",
+        "hard_invariants",
+    }
+
+    missing = sorted(required_fields - set(policy))
+    errors.extend(f"missing required TTL policy field: {field}" for field in missing)
+
+    if errors:
+        return errors
+
+    posture = policy["posture"]
+    required_true_posture = {
+        "authority_expires",
+        "uncertainty_degrades_permission",
+        "graceful_degradation_preferred",
+        "hard_stop_on_forbidden_capability",
+        "human_approval_required_for_renewal",
+    }
+
+    for field in sorted(required_true_posture):
+        if posture.get(field) is not True:
+            errors.append(f"TTL posture must declare {field}=true")
+
+    modes = policy["modes"]
+    ranks = policy["authority_rank"]
+
+    if not isinstance(modes, dict):
+        errors.append("TTL policy modes must be an object")
+        return errors
+
+    if not isinstance(ranks, dict):
+        errors.append("TTL policy authority_rank must be an object")
+        return errors
+
+    for mode, mode_policy in modes.items():
+        if mode not in ranks:
+            errors.append(f"mode missing authority rank: {mode}")
+
+        target = mode_policy.get("degradation_target")
+        if target not in modes:
+            errors.append(f"mode has unknown degradation target: {mode}->{target}")
+            continue
+
+        if target not in ranks:
+            errors.append(f"degradation target missing authority rank: {target}")
+            continue
+
+        if mode in ranks and ranks[target] > ranks[mode]:
+            errors.append(f"degradation increases authority: {mode}->{target}")
+
+        if mode_policy.get("ttl_required") is True:
+            max_ttl = mode_policy.get("max_ttl_minutes")
+            if not isinstance(max_ttl, int) or max_ttl <= 0:
+                errors.append(f"TTL-required mode lacks positive max TTL: {mode}")
+
+    list_fields = {
+        "ttl_shortening_signals",
+        "graceful_degradation_triggers",
+        "hard_stop_triggers",
+        "human_approval_required_for",
+        "safe_outputs_after_degradation",
+        "hard_invariants",
+    }
+
+    for field in sorted(list_fields):
+        if not isinstance(policy[field], list):
+            errors.append(f"TTL policy field must be a list: {field}")
+
+    return errors
+
+
+def _cap_ttl_minutes(
+    current_ttl_minutes: Any,
+    mode_policy: dict[str, Any],
+) -> int | None:
+    max_ttl = mode_policy.get("max_ttl_minutes")
+
+    if current_ttl_minutes is None:
+        return max_ttl
+
+    ttl = int(current_ttl_minutes)
+
+    if max_ttl is None:
+        return ttl
+
+    return min(ttl, int(max_ttl))
+
+
+def _shorten_ttl_minutes(ttl_minutes: int | None) -> int | None:
+    if ttl_minutes is None:
+        return None
+    return max(1, ttl_minutes // 2)
+
+
+def evaluate_ttl_state(
+    state: dict[str, Any],
+    policy: dict[str, Any] | None = None,
+    policy_path: Path | str = DEFAULT_TTL_POLICY_PATH,
+) -> dict[str, Any]:
+    """Evaluate a proposed TTL state against policy.
+
+    The result is advisory and artifact-safe. It cannot grant authority.
+    """
+    if policy is None:
+        policy = load_ttl_policy(policy_path)
+
+    errors = validate_ttl_policy_shape(policy)
+    mode = state.get("mode")
+
+    base_result: dict[str, Any] = {
+        "valid": False,
+        "mode": mode,
+        "effective_mode": None,
+        "degraded_to": None,
+        "hard_stop": False,
+        "ttl_minutes": None,
+        "ttl_shortened": False,
+        "safe_outputs": [],
+        "human_approval_required": False,
+        "reverse_execution_channel_opened": False,
+        "reasons": [],
+        "errors": errors,
+    }
+
+    if errors:
+        return base_result
+
+    modes = policy["modes"]
+    if mode not in modes:
+        base_result["errors"] = [*errors, f"unknown TTL mode: {mode}"]
+        return base_result
+
+    mode_policy = modes[mode]
+    target = mode_policy["degradation_target"]
+    safe_outputs = list(policy["safe_outputs_after_degradation"])
+
+    signals = _as_string_set(state.get("signals"))
+    requested_capabilities = _as_string_set(state.get("requested_capabilities"))
+    claimed_capabilities = _as_string_set(state.get("claimed_capabilities"))
+    capability_claims = requested_capabilities | claimed_capabilities
+
+    hard_stop_triggers = set(policy["hard_stop_triggers"])
+    hard_hits = sorted(capability_claims & hard_stop_triggers)
+
+    ttl_minutes = _cap_ttl_minutes(state.get("current_ttl_minutes"), mode_policy)
+    ttl_shortened = False
+    reasons: list[str] = []
+
+    if hard_hits:
+        reasons.extend(f"hard_stop:{hit}" for hit in hard_hits)
+        return {
+            **base_result,
+            "valid": True,
+            "effective_mode": "artifact_only",
+            "degraded_to": "artifact_only",
+            "hard_stop": True,
+            "ttl_minutes": None,
+            "ttl_shortened": False,
+            "safe_outputs": safe_outputs,
+            "human_approval_required": True,
+            "reasons": reasons,
+            "errors": [],
+        }
+
+    shortening_hits = sorted(signals & set(policy["ttl_shortening_signals"]))
+    if mode_policy.get("ttl_required") is True and shortening_hits:
+        ttl_minutes = _shorten_ttl_minutes(ttl_minutes)
+        ttl_shortened = True
+        reasons.extend(f"ttl_shortened:{hit}" for hit in shortening_hits)
+
+    graceful_hits = sorted(signals & set(policy["graceful_degradation_triggers"]))
+    ttl_expired = bool(state.get("ttl_expired", False))
+    ttl_missing = (
+        mode_policy.get("ttl_required") is True and state.get("current_ttl_minutes") is None
+    )
+
+    should_degrade = ttl_expired or bool(graceful_hits) or ttl_missing
+
+    if ttl_expired:
+        reasons.append("ttl_expired")
+
+    if ttl_missing:
+        reasons.append("ttl_required_but_missing")
+
+    reasons.extend(f"graceful_degradation:{hit}" for hit in graceful_hits)
+
+    effective_mode = target if should_degrade else mode
+    degraded_to = effective_mode if should_degrade else None
+
+    return {
+        **base_result,
+        "valid": True,
+        "effective_mode": effective_mode,
+        "degraded_to": degraded_to,
+        "hard_stop": False,
+        "ttl_minutes": ttl_minutes,
+        "ttl_shortened": ttl_shortened,
+        "safe_outputs": safe_outputs if should_degrade else [],
+        "human_approval_required": should_degrade,
+        "reasons": reasons,
+        "errors": [],
+    }

--- a/tests/test_ttl_policy_evaluator.py
+++ b/tests/test_ttl_policy_evaluator.py
@@ -1,0 +1,124 @@
+from eve_q.ttl_policy import (
+    evaluate_ttl_state,
+    load_ttl_policy,
+    validate_ttl_policy_shape,
+)
+
+
+def test_ttl_policy_shape_is_valid():
+    assert validate_ttl_policy_shape(load_ttl_policy()) == []
+
+
+def test_expired_ttl_degrades_to_declared_target():
+    result = evaluate_ttl_state(
+        {
+            "mode": "human_gated_execution",
+            "ttl_expired": True,
+            "current_ttl_minutes": 30,
+            "signals": [],
+        }
+    )
+
+    assert result["valid"] is True
+    assert result["hard_stop"] is False
+    assert result["effective_mode"] == "shadow_live_market_data"
+    assert result["degraded_to"] == "shadow_live_market_data"
+    assert result["human_approval_required"] is True
+    assert "ttl_expired" in result["reasons"]
+
+
+def test_hard_stop_claim_emits_safe_artifact_only():
+    policy = load_ttl_policy()
+    result = evaluate_ttl_state(
+        {
+            "mode": "human_gated_execution",
+            "current_ttl_minutes": 30,
+            "requested_capabilities": ["wallet_signing"],
+            "signals": [],
+        },
+        policy=policy,
+    )
+
+    assert result["valid"] is True
+    assert result["hard_stop"] is True
+    assert result["effective_mode"] == "artifact_only"
+    assert result["degraded_to"] == "artifact_only"
+    assert result["human_approval_required"] is True
+    assert result["reverse_execution_channel_opened"] is False
+    assert result["safe_outputs"] == policy["safe_outputs_after_degradation"]
+    assert "hard_stop:wallet_signing" in result["reasons"]
+
+
+def test_ttl_shortening_signal_reduces_active_window():
+    result = evaluate_ttl_state(
+        {
+            "mode": "shadow_live_market_data",
+            "current_ttl_minutes": 60,
+            "signals": ["market_volatility_spike"],
+        }
+    )
+
+    assert result["valid"] is True
+    assert result["hard_stop"] is False
+    assert result["ttl_shortened"] is True
+    assert result["ttl_minutes"] < 60
+    assert result["ttl_minutes"] >= 1
+    assert result["effective_mode"] == "shadow_live_market_data"
+
+
+def test_unknown_mode_is_invalid():
+    result = evaluate_ttl_state({"mode": "god_mode"})
+
+    assert result["valid"] is False
+    assert result["effective_mode"] is None
+    assert result["errors"] == ["unknown TTL mode: god_mode"]
+
+
+def test_missing_ttl_for_ttl_required_mode_degrades():
+    result = evaluate_ttl_state(
+        {
+            "mode": "testnet",
+            "signals": [],
+        }
+    )
+
+    assert result["valid"] is True
+    assert result["effective_mode"] == "simulation"
+    assert result["degraded_to"] == "simulation"
+    assert result["human_approval_required"] is True
+    assert "ttl_required_but_missing" in result["reasons"]
+
+
+def test_degradation_never_increases_authority():
+    policy = load_ttl_policy()
+    ranks = policy["authority_rank"]
+
+    for mode, mode_policy in policy["modes"].items():
+        result = evaluate_ttl_state(
+            {
+                "mode": mode,
+                "ttl_expired": True,
+                "current_ttl_minutes": mode_policy["max_ttl_minutes"],
+                "signals": [],
+            },
+            policy=policy,
+        )
+
+        assert result["valid"] is True
+        assert ranks[result["effective_mode"]] <= ranks[mode]
+
+
+def test_no_trigger_preserves_safe_mode():
+    result = evaluate_ttl_state(
+        {
+            "mode": "simulation",
+            "signals": [],
+        }
+    )
+
+    assert result["valid"] is True
+    assert result["hard_stop"] is False
+    assert result["effective_mode"] == "simulation"
+    assert result["degraded_to"] is None
+    assert result["human_approval_required"] is False
+    assert result["safe_outputs"] == []


### PR DESCRIPTION
Adds a pure deterministic TTL policy evaluator for CodexTradingEngine.

Scope:
- loads and validates ttl_policy.json
- evaluates expired TTL degradation
- handles hard-stop capability claims
- shortens TTL under uncertainty signals
- rejects unknown modes
- preserves safe modes when no trigger fires
- expands CI coverage for evaluator surfaces

Safety boundary:
- no scheduler
- no wallet access
- no network access
- no background loop
- no capital movement
- evaluator is advisory/artifact-safe only

Law:
Policy reads.
Evaluator judges.
Authority still does not move.
Human promotes.

Closes #14 follow-up.