### PR TITLE
Add artifact carrier manifest example

### DIFF
--- a/docs/artifact_carrier_manifest_example.md
+++ b/docs/artifact_carrier_manifest_example.md
@@ -1,0 +1,69 @@
+# Artifact Carrier Manifest Example
+
+This example demonstrates a safe CID-backed artifact carrier manifest.
+
+The carrier manifest is a pointer. It is not a command, scheduler, wallet, execution request, or authority source.
+
+## Carrier Law
+
+```text
+The image carries the acorn.
+The CID points to the memory.
+The key is consent.
+The artifact never commands.
+```
+
+## Example Manifest
+
+The canonical example lives at:
+
+```text
+examples/artifact_carrier_manifest.example.json
+```
+
+It demonstrates:
+
+- a CID-backed encrypted continuity-spore pointer
+- artifact-only TTL mode
+- human-held key custody
+- no execution authority
+- no reverse execution channel
+- no embedded secrets
+- no wallet or command fields
+
+## Interpretation
+
+A carrier manifest may say where an encrypted payload lives. It must not say what must execute.
+
+Safe chain:
+
+```text
+visible artifact
+-> metadata pointer
+-> CID
+-> encrypted payload
+-> human-held key
+-> human review
+```
+
+Unsafe chain:
+
+```text
+artifact
+-> command
+-> execution
+```
+
+That unsafe chain is forbidden.
+
+## Validation
+
+The example is tested by:
+
+```text
+tests/test_artifact_carrier_example.py
+```
+
+The example teaches.
+The validator verifies.
+The artifact still does not command.

--- a/examples/artifact_carrier_manifest.example.json
+++ b/examples/artifact_carrier_manifest.example.json
@@ -1,0 +1,17 @@
+{
+  "schema": "spiralbloom.artifact_carrier.v0.1",
+  "version": "0.1.0",
+  "artifact_type": "encrypted_spore_pointer",
+  "cid": "bafybeigdyrzt5sfp7udm7hu76qpq7ka7gskp5b4rq6x2zq4zzzzzz",
+  "payload_class": "encrypted",
+  "payload_type": "continuity_spore",
+  "ttl_mode": "artifact_only",
+  "human_promotion_required": true,
+  "execution_authority": "none",
+  "reverse_execution_channel_opened": false,
+  "description": "Example CID-backed encrypted memory pointer. The payload is detached and encrypted.",
+  "encryption": {
+    "status": "encrypted",
+    "key_custody": "human_held"
+  }
+}

--- a/tests/test_artifact_carrier_example.py
+++ b/tests/test_artifact_carrier_example.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from eve_q.artifact_carrier import validate_artifact_carrier_manifest
+
+EXAMPLE_PATH = Path("examples/artifact_carrier_manifest.example.json")
+DOC_PATH = Path("docs/artifact_carrier_manifest_example.md")
+
+
+def test_artifact_carrier_example_manifest_validates():
+    manifest = json.loads(EXAMPLE_PATH.read_text())
+
+    assert validate_artifact_carrier_manifest(manifest) == []
+
+
+def test_artifact_carrier_example_is_pointer_not_authority():
+    manifest = json.loads(EXAMPLE_PATH.read_text())
+
+    assert manifest["ttl_mode"] == "artifact_only"
+    assert manifest["human_promotion_required"] is True
+    assert manifest["execution_authority"] == "none"
+    assert manifest["reverse_execution_channel_opened"] is False
+
+
+def test_artifact_carrier_example_keeps_key_with_human():
+    manifest = json.loads(EXAMPLE_PATH.read_text())
+
+    assert manifest["payload_class"] == "encrypted"
+    assert manifest["encryption"]["status"] == "encrypted"
+    assert manifest["encryption"]["key_custody"] == "human_held"
+
+
+def test_artifact_carrier_example_doc_preserves_carrier_law():
+    doc = DOC_PATH.read_text()
+
+    assert "The CID points to the memory." in doc
+    assert "The key is consent." in doc
+    assert "The artifact never commands." in doc
+    assert "It must not say what must execute." in doc


### PR DESCRIPTION
Adds a safe, executable example for artifact carrier manifests.

Scope:
- documents the artifact carrier law
- adds an example CID-backed encrypted continuity-spore pointer
- validates the example against the pure carrier validator
- verifies artifact-only TTL mode
- verifies human-held key custody
- verifies no execution authority
- verifies no reverse execution channel

Safety boundary:
- example only
- no IPFS daemon dependency
- no image metadata writing
- no exiftool dependency
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The example teaches.
The validator verifies.
The artifact still does not command.