### PR TITLE
Add CI coverage for artifact carrier examples

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -22,6 +22,9 @@ on:
       - 'tests/test_ttl_policy_scaffold.py'
       - 'tests/test_ttl_policy_evaluator.py'
       - 'tests/test_artifact_carrier_manifest.py'
+      - 'tests/test_artifact_carrier_example.py'
+      - 'examples/artifact_carrier_manifest.example.json'
+      - 'docs/artifact_carrier_manifest_example.md'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -98,6 +101,7 @@ jobs:
             tests/test_ttl_policy_scaffold.py \
           tests/test_ttl_policy_evaluator.py \
           tests/test_artifact_carrier_manifest.py \
+          tests/test_artifact_carrier_example.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,9 @@ on:
       - 'tests/test_ttl_policy_scaffold.py'
       - 'tests/test_ttl_policy_evaluator.py'
       - 'tests/test_artifact_carrier_manifest.py'
+      - 'tests/test_artifact_carrier_example.py'
+      - 'examples/artifact_carrier_manifest.example.json'
+      - 'docs/artifact_carrier_manifest_example.md'
       - 'tests/test_charity_allocation_diversity_guard.py'
       - 'tests/test_need_impact_scoring.py'
       - 'requirements.txt'
@@ -98,6 +101,7 @@ jobs:
             tests/test_ttl_policy_scaffold.py \
           tests/test_ttl_policy_evaluator.py \
           tests/test_artifact_carrier_manifest.py \
+          tests/test_artifact_carrier_example.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 


### PR DESCRIPTION
Adds GitHub Actions coverage for artifact carrier example surfaces.

Scope:
- triggers CI when the artifact carrier example doc changes
- triggers CI when the artifact carrier example JSON changes
- triggers CI when the artifact carrier example test changes
- includes the example test in workflow pytest targets

Reason:
PR #22 was locally validated and mergeable, but GitHub reported no checks because docs/examples/example-test paths were not covered by workflow triggers.

Principle:
The example teaches.
The validator verifies.
CI remembers to check the teaching artifact.