### PR TITLE
Add receipt carrier attestation example

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -24,6 +24,9 @@ on:
       - 'tests/test_artifact_carrier_manifest.py'
       - 'tests/test_artifact_carrier_example.py'
       - 'tests/test_receipt_carrier_attestation.py'
+      - 'tests/test_receipt_carrier_attestation_example.py'
+      - 'examples/receipt_carrier_attestation.example.json'
+      - 'docs/receipt_carrier_attestation_example.md'
       - 'eve_q/receipt_carrier_attestation.py'
       - 'examples/artifact_carrier_manifest.example.json'
       - 'docs/artifact_carrier_manifest_example.md'
@@ -106,6 +109,7 @@ jobs:
           tests/test_artifact_carrier_manifest.py \
           tests/test_artifact_carrier_example.py \
           tests/test_receipt_carrier_attestation.py \
+          tests/test_receipt_carrier_attestation_example.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,9 @@ on:
       - 'tests/test_artifact_carrier_manifest.py'
       - 'tests/test_artifact_carrier_example.py'
       - 'tests/test_receipt_carrier_attestation.py'
+      - 'tests/test_receipt_carrier_attestation_example.py'
+      - 'examples/receipt_carrier_attestation.example.json'
+      - 'docs/receipt_carrier_attestation_example.md'
       - 'eve_q/receipt_carrier_attestation.py'
       - 'examples/artifact_carrier_manifest.example.json'
       - 'docs/artifact_carrier_manifest_example.md'
@@ -106,6 +109,7 @@ jobs:
           tests/test_artifact_carrier_manifest.py \
           tests/test_artifact_carrier_example.py \
           tests/test_receipt_carrier_attestation.py \
+          tests/test_receipt_carrier_attestation_example.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/docs/receipt_carrier_attestation_example.md
+++ b/docs/receipt_carrier_attestation_example.md
@@ -1,0 +1,69 @@
+# Receipt Carrier Attestation Example
+
+This example demonstrates a safe receipt-to-carrier attestation.
+
+The attestation binds a receipt identifier to a carrier manifest digest and CID. It does not create execution authority.
+
+## Attestation Law
+
+```text
+Receipt remembers.
+Carrier points.
+TTL expires.
+Human promotes.
+```
+
+## Example Files
+
+Carrier manifest:
+
+```text
+examples/artifact_carrier_manifest.example.json
+```
+
+Receipt carrier attestation:
+
+```text
+examples/receipt_carrier_attestation.example.json
+```
+
+## What The Attestation Proves
+
+The example attestation records:
+
+- the receipt identifier
+- the carrier manifest SHA-256 digest
+- the carrier CID
+- artifact-only TTL mode
+- human promotion requirement
+- no execution authority
+- no reverse execution channel
+
+## What The Attestation Does Not Do
+
+The attestation does not:
+
+- execute commands
+- sign wallets
+- move capital
+- schedule actions
+- mutate receipts
+- open a reverse execution channel
+
+## Safe Chain
+
+```text
+receipt
+-> carrier manifest digest
+-> carrier CID
+-> encrypted payload pointer
+-> human review
+```
+
+## Drift Detection
+
+If the carrier manifest changes after attestation, the SHA-256 digest changes and validation fails.
+
+The attestation binds.
+The hash detects drift.
+The carrier still does not command.

--- a/examples/receipt_carrier_attestation.example.json
+++ b/examples/receipt_carrier_attestation.example.json
@@ -1,0 +1,12 @@
+{
+  "schema": "spiralbloom.receipt_carrier_attestation.v0.1",
+  "version": "0.1.0",
+  "attestation_type": "receipt_carrier_binding",
+  "receipt_id": "receipt_example_001",
+  "carrier_manifest_sha256": "6c51cef59ec337bb5df0d192fbfec8c6d1d3d5ce7809fbf14f0c205999afd2fa",
+  "carrier_cid": "bafybeigdyrzt5sfp7udm7hu76qpq7ka7gskp5b4rq6x2zq4zzzzzz",
+  "ttl_mode": "artifact_only",
+  "human_promotion_required": true,
+  "execution_authority": "none",
+  "reverse_execution_channel_opened": false
+}

--- a/tests/test_receipt_carrier_attestation_example.py
+++ b/tests/test_receipt_carrier_attestation_example.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+from eve_q.receipt_carrier_attestation import (
+    sha256_manifest,
+    validate_receipt_carrier_attestation,
+)
+
+CARRIER_PATH = Path("examples/artifact_carrier_manifest.example.json")
+ATTESTATION_PATH = Path("examples/receipt_carrier_attestation.example.json")
+DOC_PATH = Path("docs/receipt_carrier_attestation_example.md")
+
+
+def load_carrier_manifest():
+    return json.loads(CARRIER_PATH.read_text())
+
+
+def load_attestation():
+    return json.loads(ATTESTATION_PATH.read_text())
+
+
+def test_receipt_carrier_attestation_example_validates():
+    manifest = load_carrier_manifest()
+    attestation = load_attestation()
+
+    assert validate_receipt_carrier_attestation(attestation, manifest) == []
+
+
+def test_receipt_carrier_attestation_example_binds_manifest_hash():
+    manifest = load_carrier_manifest()
+    attestation = load_attestation()
+
+    assert attestation["carrier_manifest_sha256"] == sha256_manifest(manifest)
+
+
+def test_receipt_carrier_attestation_example_binds_carrier_cid():
+    manifest = load_carrier_manifest()
+    attestation = load_attestation()
+
+    assert attestation["carrier_cid"] == manifest["cid"]
+
+
+def test_receipt_carrier_attestation_example_is_review_artifact_only():
+    attestation = load_attestation()
+
+    assert attestation["ttl_mode"] == "artifact_only"
+    assert attestation["human_promotion_required"] is True
+    assert attestation["execution_authority"] == "none"
+    assert attestation["reverse_execution_channel_opened"] is False
+
+
+def test_receipt_carrier_attestation_example_doc_preserves_law():
+    doc = DOC_PATH.read_text()
+
+    assert "Receipt remembers." in doc
+    assert "Carrier points." in doc
+    assert "TTL expires." in doc
+    assert "Human promotes." in doc
+    assert "The carrier still does not command." in doc


### PR DESCRIPTION
Adds a safe, executable example for receipt carrier attestations.

Scope:
- adds an example receipt-to-carrier attestation JSON artifact
- documents the receipt carrier attestation law
- validates the example against the pure attestation validator
- verifies carrier manifest SHA-256 binding
- verifies carrier CID binding
- verifies artifact_only TTL mode
- verifies human_promotion_required=true
- verifies execution_authority=none
- verifies reverse_execution_channel_opened=false
- adds CI coverage for the example surfaces

Safety boundary:
- example only
- no IPFS daemon dependency
- no image metadata writing
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The attestation binds.
The hash detects drift.
The carrier still does not command.