### PR TITLE
Add README constitutional surface index

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -25,6 +25,8 @@ on:
       - 'tests/test_artifact_carrier_example.py'
       - 'tests/test_receipt_carrier_attestation.py'
       - 'tests/test_receipt_carrier_attestation_example.py'
+      - 'tests/test_readme_constitutional_surface_index.py'
+      - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
       - 'eve_q/receipt_carrier_attestation.py'
@@ -110,6 +112,7 @@ jobs:
           tests/test_artifact_carrier_example.py \
           tests/test_receipt_carrier_attestation.py \
           tests/test_receipt_carrier_attestation_example.py \
+          tests/test_readme_constitutional_surface_index.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,8 @@ on:
       - 'tests/test_artifact_carrier_example.py'
       - 'tests/test_receipt_carrier_attestation.py'
       - 'tests/test_receipt_carrier_attestation_example.py'
+      - 'tests/test_readme_constitutional_surface_index.py'
+      - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
       - 'eve_q/receipt_carrier_attestation.py'
@@ -110,6 +112,7 @@ jobs:
           tests/test_artifact_carrier_example.py \
           tests/test_receipt_carrier_attestation.py \
           tests/test_receipt_carrier_attestation_example.py \
+          tests/test_readme_constitutional_surface_index.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/README.md
+++ b/README.md
@@ -92,3 +92,40 @@ It is not a transaction signer.
 It is not financial advice.
 
 Human review and explicit human promotion remain required for any real-world capital touchpoint.
+
+<!-- constitutional-surfaces-index:start -->
+
+## Constitutional Surfaces Index
+
+CodexTradingEngine is simulation-first and safety-gated. These surfaces define the current artifact membrane:
+
+| Surface | File | Purpose |
+| --- | --- | --- |
+| Artifact carrier validator | `eve_q/artifact_carrier.py` | Validates CID-backed carrier manifests without granting execution authority. |
+| Artifact carrier example | `examples/artifact_carrier_manifest.example.json` | Provides a deterministic teaching artifact for safe carrier manifests. |
+| Artifact carrier example docs | `docs/artifact_carrier_manifest_example.md` | Documents the carrier law: the artifact carries memory, not authority. |
+| Receipt carrier attestation validator | `eve_q/receipt_carrier_attestation.py` | Binds a receipt identifier to a carrier manifest digest and CID as a review artifact. |
+| Receipt carrier attestation example | `examples/receipt_carrier_attestation.example.json` | Demonstrates safe receipt-to-carrier attestation. |
+| Receipt carrier attestation docs | `docs/receipt_carrier_attestation_example.md` | Documents attestation drift detection and non-execution boundaries. |
+
+Current law:
+
+```text
+Receipt remembers.
+Carrier points.
+Hash detects drift.
+TTL expires.
+CI guards.
+Human promotes.
+```
+
+Safety boundary:
+
+- no autonomous capital movement
+- no wallet signing
+- no scheduler authority
+- no reverse execution channel
+- no IPFS daemon dependency for validation
+- no image metadata dependency for validation
+
+<!-- constitutional-surfaces-index:end -->

--- a/tests/test_readme_constitutional_surface_index.py
+++ b/tests/test_readme_constitutional_surface_index.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+README = Path("README.md")
+
+
+def test_readme_names_current_constitutional_surfaces():
+    text = README.read_text()
+
+    required = [
+        "Constitutional Surfaces Index",
+        "eve_q/artifact_carrier.py",
+        "examples/artifact_carrier_manifest.example.json",
+        "docs/artifact_carrier_manifest_example.md",
+        "eve_q/receipt_carrier_attestation.py",
+        "examples/receipt_carrier_attestation.example.json",
+        "docs/receipt_carrier_attestation_example.md",
+    ]
+
+    for item in required:
+        assert item in text
+
+
+def test_readme_preserves_non_execution_boundary():
+    text = README.read_text()
+
+    required = [
+        "no autonomous capital movement",
+        "no wallet signing",
+        "no scheduler authority",
+        "no reverse execution channel",
+        "Human promotes.",
+    ]
+
+    for item in required:
+        assert item in text


### PR DESCRIPTION
Adds a public README index for the current constitutional artifact surfaces.

Scope:
- lists artifact carrier validator and example surfaces
- lists receipt carrier attestation validator and example surfaces
- documents the non-execution safety boundary
- adds tests that guard the README index
- adds CI coverage for the README index test

Safety boundary:
- documentation and tests only
- no runtime behavior changes
- no IPFS daemon dependency
- no wallet access
- no scheduler
- no capital movement

Law:
README names the surfaces.
Tests guard the index.
CI remembers the map.