### PR TITLE
Add receipt carrier attestation CLI

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -26,6 +26,7 @@ on:
       - 'tests/test_receipt_carrier_attestation.py'
       - 'tests/test_receipt_carrier_attestation_example.py'
       - 'tests/test_readme_constitutional_surface_index.py'
+      - 'tests/test_receipt_carrier_attestation_cli.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
@@ -113,6 +114,7 @@ jobs:
           tests/test_receipt_carrier_attestation.py \
           tests/test_receipt_carrier_attestation_example.py \
           tests/test_readme_constitutional_surface_index.py \
+          tests/test_receipt_carrier_attestation_cli.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ on:
       - 'tests/test_receipt_carrier_attestation.py'
       - 'tests/test_receipt_carrier_attestation_example.py'
       - 'tests/test_readme_constitutional_surface_index.py'
+      - 'tests/test_receipt_carrier_attestation_cli.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
@@ -113,6 +114,7 @@ jobs:
           tests/test_receipt_carrier_attestation.py \
           tests/test_receipt_carrier_attestation_example.py \
           tests/test_readme_constitutional_surface_index.py \
+          tests/test_receipt_carrier_attestation_cli.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/eve_q/receipt_carrier_attestation.py
+++ b/eve_q/receipt_carrier_attestation.py
@@ -6,6 +6,7 @@ execution authority. The attestation is a review artifact only.
 
 from __future__ import annotations
 
+import argparse
 import hashlib
 import json
 from collections.abc import Mapping
@@ -143,3 +144,37 @@ def validate_receipt_carrier_attestation(
         errors.append("attestation must not open reverse execution channel")
 
     return sorted(set(errors))
+
+
+def validate_receipt_carrier_attestation_files(
+    carrier_path: Path | str,
+    attestation_path: Path | str,
+) -> dict[str, Any]:
+    """Validate carrier and attestation JSON files."""
+    carrier_manifest = load_json(carrier_path)
+    attestation = load_json(attestation_path)
+    errors = validate_receipt_carrier_attestation(attestation, carrier_manifest)
+    return {"valid": errors == [], "errors": errors}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the local attestation validator CLI."""
+    parser = argparse.ArgumentParser(description="Validate a receipt carrier attestation.")
+    parser.add_argument("--carrier", required=True)
+    parser.add_argument("--attestation", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        result = validate_receipt_carrier_attestation_files(
+            carrier_path=args.carrier,
+            attestation_path=args.attestation,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        result = {"valid": False, "errors": [f"failed to load input: {exc}"]}
+
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_receipt_carrier_attestation_cli.py
+++ b/tests/test_receipt_carrier_attestation_cli.py
@@ -1,0 +1,59 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CARRIER_PATH = Path("examples/artifact_carrier_manifest.example.json")
+ATTESTATION_PATH = Path("examples/receipt_carrier_attestation.example.json")
+
+
+def run_cli(carrier_path, attestation_path):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.receipt_carrier_attestation",
+            "--carrier",
+            str(carrier_path),
+            "--attestation",
+            str(attestation_path),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_receipt_carrier_attestation_cli_validates_examples():
+    result = run_cli(CARRIER_PATH, ATTESTATION_PATH)
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {"errors": [], "valid": True}
+    assert result.stderr == ""
+
+
+def test_receipt_carrier_attestation_cli_reports_manifest_drift(tmp_path):
+    carrier = json.loads(CARRIER_PATH.read_text())
+    carrier["payload_type"] = "changed_payload"
+
+    drifted_carrier = tmp_path / "carrier.json"
+    drifted_carrier.write_text(json.dumps(carrier))
+
+    result = run_cli(drifted_carrier, ATTESTATION_PATH)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert "carrier_manifest_sha256 mismatch" in payload["errors"]
+
+
+def test_receipt_carrier_attestation_cli_reports_missing_file(tmp_path):
+    missing = tmp_path / "missing.json"
+
+    result = run_cli(missing, ATTESTATION_PATH)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert payload["errors"]
+    assert payload["errors"][0].startswith("failed to load input:")


### PR DESCRIPTION
Adds a pure local CLI for receipt carrier attestation validation.

Scope:
- adds python -m eve_q.receipt_carrier_attestation
- validates carrier and attestation JSON files from shell
- emits deterministic JSON output
- returns exit code 0 when valid
- returns exit code 1 when invalid
- detects carrier manifest drift
- reports missing or invalid input files
- adds CLI tests
- adds CI coverage for the CLI test

Safety boundary:
- local validation only
- no IPFS daemon dependency
- no image metadata writing
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
Operator asks.
Validator answers.
Receipt remembers.
Carrier points.
Human promotes.