### PR TITLE
Add artifact carrier manifest CLI

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -27,6 +27,7 @@ on:
       - 'tests/test_receipt_carrier_attestation_example.py'
       - 'tests/test_readme_constitutional_surface_index.py'
       - 'tests/test_receipt_carrier_attestation_cli.py'
+      - 'tests/test_artifact_carrier_cli.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
@@ -115,6 +116,7 @@ jobs:
           tests/test_receipt_carrier_attestation_example.py \
           tests/test_readme_constitutional_surface_index.py \
           tests/test_receipt_carrier_attestation_cli.py \
+          tests/test_artifact_carrier_cli.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ on:
       - 'tests/test_receipt_carrier_attestation_example.py'
       - 'tests/test_readme_constitutional_surface_index.py'
       - 'tests/test_receipt_carrier_attestation_cli.py'
+      - 'tests/test_artifact_carrier_cli.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
@@ -115,6 +116,7 @@ jobs:
           tests/test_receipt_carrier_attestation_example.py \
           tests/test_readme_constitutional_surface_index.py \
           tests/test_receipt_carrier_attestation_cli.py \
+          tests/test_artifact_carrier_cli.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/eve_q/artifact_carrier.py
+++ b/eve_q/artifact_carrier.py
@@ -6,6 +6,7 @@ not grant authority, execute commands, hold secrets, or move capital.
 
 from __future__ import annotations
 
+import argparse
 import json
 import re
 from collections.abc import Iterable, Mapping
@@ -260,3 +261,39 @@ def validate_artifact_carrier_manifest(
     errors.extend(_validate_encryption_block(manifest, contract))
 
     return sorted(set(errors))
+
+
+def load_json(path: Path | str) -> dict[str, Any]:
+    """Load a JSON object from disk."""
+    value = json.loads(Path(path).read_text())
+    if not isinstance(value, dict):
+        raise ValueError("expected JSON object")
+    return value
+
+
+def validate_artifact_carrier_manifest_file(
+    manifest_path: Path | str,
+) -> dict[str, Any]:
+    """Validate an artifact carrier manifest JSON file."""
+    manifest = load_json(manifest_path)
+    errors = validate_artifact_carrier_manifest(manifest)
+    return {"valid": errors == [], "errors": errors}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the local artifact carrier manifest validator CLI."""
+    parser = argparse.ArgumentParser(description="Validate an artifact carrier manifest.")
+    parser.add_argument("--manifest", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        result = validate_artifact_carrier_manifest_file(args.manifest)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        result = {"valid": False, "errors": [f"failed to load input: {exc}"]}
+
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_artifact_carrier_cli.py
+++ b/tests/test_artifact_carrier_cli.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MANIFEST_PATH = Path("examples/artifact_carrier_manifest.example.json")
+
+
+def run_cli(manifest_path):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.artifact_carrier",
+            "--manifest",
+            str(manifest_path),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_artifact_carrier_cli_validates_example_manifest():
+    result = run_cli(MANIFEST_PATH)
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {"errors": [], "valid": True}
+    assert result.stderr == ""
+
+
+def test_artifact_carrier_cli_reports_invalid_manifest(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    manifest["execution_authority"] = "scheduler"
+
+    invalid_manifest = tmp_path / "invalid_manifest.json"
+    invalid_manifest.write_text(json.dumps(manifest))
+
+    result = run_cli(invalid_manifest)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert any("execution_authority must be none" in error for error in payload["errors"])
+
+
+def test_artifact_carrier_cli_reports_missing_file(tmp_path):
+    missing = tmp_path / "missing.json"
+
+    result = run_cli(missing)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert payload["errors"]
+    assert payload["errors"][0].startswith("failed to load input:")


### PR DESCRIPTION
Adds a pure local CLI for artifact carrier manifest validation.

Scope:
- adds python -m eve_q.artifact_carrier
- validates carrier manifest JSON files from shell
- emits deterministic JSON output
- returns exit code 0 when valid
- returns exit code 1 when invalid
- reports missing or invalid input files
- adds CLI tests
- adds CI coverage for the CLI test

Safety boundary:
- local validation only
- no IPFS daemon dependency
- no image metadata writing
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
Operator asks.
Carrier validator answers.
The artifact carries memory, not authority.