### PR TITLE
Add membrane metadata extractor

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -28,6 +28,8 @@ on:
       - 'tests/test_readme_constitutional_surface_index.py'
       - 'tests/test_receipt_carrier_attestation_cli.py'
       - 'tests/test_artifact_carrier_cli.py'
+      - 'tests/test_membrane_tool.py'
+      - 'eve_q/membrane_tool.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
@@ -97,6 +99,7 @@ jobs:
             eve_q/organ_contract.py \
           eve_q/ttl_policy.py \
           eve_q/artifact_carrier.py \
+          eve_q/membrane_tool.py \
           eve_q/receipt_carrier_attestation.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
@@ -117,6 +120,7 @@ jobs:
           tests/test_readme_constitutional_surface_index.py \
           tests/test_receipt_carrier_attestation_cli.py \
           tests/test_artifact_carrier_cli.py \
+          tests/test_membrane_tool.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,8 @@ on:
       - 'tests/test_readme_constitutional_surface_index.py'
       - 'tests/test_receipt_carrier_attestation_cli.py'
       - 'tests/test_artifact_carrier_cli.py'
+      - 'tests/test_membrane_tool.py'
+      - 'eve_q/membrane_tool.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
       - 'docs/receipt_carrier_attestation_example.md'
@@ -97,6 +99,7 @@ jobs:
             eve_q/organ_contract.py \
           eve_q/ttl_policy.py \
           eve_q/artifact_carrier.py \
+          eve_q/membrane_tool.py \
           eve_q/receipt_carrier_attestation.py \
             eve_q/allocation/charity_router.py \
             eve_q/allocation/geodesic_policy.py \
@@ -117,6 +120,7 @@ jobs:
           tests/test_readme_constitutional_surface_index.py \
           tests/test_receipt_carrier_attestation_cli.py \
           tests/test_artifact_carrier_cli.py \
+          tests/test_membrane_tool.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/eve_q/membrane_tool.py
+++ b/eve_q/membrane_tool.py
@@ -1,0 +1,172 @@
+"""Membrane metadata extractor.
+
+Extracts a carrier manifest from PNG metadata and validates it without creating
+execution authority.
+
+Safety boundary:
+- no IPFS daemon dependency
+- no metadata writing
+- no network access
+- no wallet access
+- no scheduler
+- no capital movement
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import zlib
+from pathlib import Path
+from typing import Any
+
+from eve_q.artifact_carrier import validate_artifact_carrier_manifest
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def _read_png_chunks(image_bytes: bytes) -> list[tuple[bytes, bytes]]:
+    """Read PNG chunks as ``(chunk_type, chunk_data)`` tuples."""
+    if not image_bytes.startswith(PNG_SIGNATURE):
+        raise ValueError("unsupported image format: expected PNG")
+
+    chunks: list[tuple[bytes, bytes]] = []
+    offset = len(PNG_SIGNATURE)
+
+    while offset + 12 <= len(image_bytes):
+        length = int.from_bytes(image_bytes[offset : offset + 4], "big")
+        chunk_type = image_bytes[offset + 4 : offset + 8]
+        data_start = offset + 8
+        data_end = data_start + length
+        crc_end = data_end + 4
+
+        if crc_end > len(image_bytes):
+            raise ValueError("truncated PNG chunk")
+
+        chunk_data = image_bytes[data_start:data_end]
+        chunks.append((chunk_type, chunk_data))
+        offset = crc_end
+
+        if chunk_type == b"IEND":
+            break
+
+    return chunks
+
+
+def _decode_png_text_chunk(chunk_type: bytes, data: bytes) -> tuple[str, str] | None:
+    """Decode PNG text metadata chunks."""
+    if chunk_type == b"tEXt":
+        if b"\x00" not in data:
+            return None
+        keyword, text = data.split(b"\x00", 1)
+        return keyword.decode("latin-1"), text.decode("latin-1")
+
+    if chunk_type == b"zTXt":
+        parts = data.split(b"\x00", 1)
+        if len(parts) != 2 or not parts[1]:
+            return None
+        keyword = parts[0].decode("latin-1")
+        compression_method = parts[1][0]
+        compressed_text = parts[1][1:]
+        if compression_method != 0:
+            return None
+        return keyword, zlib.decompress(compressed_text).decode("latin-1")
+
+    if chunk_type == b"iTXt":
+        parts = data.split(b"\x00", 5)
+        if len(parts) != 6:
+            return None
+        keyword = parts[0].decode("latin-1")
+        compression_flag = parts[1]
+        compression_method = parts[2]
+        text = parts[5]
+
+        if compression_flag == b"\x01":
+            if compression_method != b"\x00":
+                return None
+            text = zlib.decompress(text)
+
+        return keyword, text.decode("utf-8")
+
+    return None
+
+
+def extract_png_text_fields(image_path: Path | str) -> dict[str, str]:
+    """Extract PNG text metadata fields."""
+    image_bytes = Path(image_path).read_bytes()
+    fields: dict[str, str] = {}
+
+    for chunk_type, chunk_data in _read_png_chunks(image_bytes):
+        decoded = _decode_png_text_chunk(chunk_type, chunk_data)
+        if decoded is None:
+            continue
+
+        keyword, text = decoded
+        fields[keyword] = text
+
+    return fields
+
+
+def extract_carrier_manifest_from_image(
+    image_path: Path | str,
+    field_name: str = "Comment",
+) -> dict[str, Any]:
+    """Extract and parse a carrier manifest JSON object from PNG metadata."""
+    fields = extract_png_text_fields(image_path)
+
+    if field_name not in fields:
+        raise ValueError(f"metadata field not found: {field_name}")
+
+    manifest = json.loads(fields[field_name])
+    if not isinstance(manifest, dict):
+        raise ValueError("metadata field did not contain a JSON object")
+
+    return manifest
+
+
+def validate_membrane_image(
+    image_path: Path | str,
+    field_name: str = "Comment",
+) -> dict[str, Any]:
+    """Extract and validate an image-carried artifact carrier manifest."""
+    manifest = extract_carrier_manifest_from_image(image_path, field_name)
+    errors = validate_artifact_carrier_manifest(manifest)
+
+    return {
+        "valid": errors == [],
+        "errors": errors,
+        "metadata_field": field_name,
+        "manifest": manifest,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the local membrane metadata extractor CLI."""
+    parser = argparse.ArgumentParser(
+        description="Extract and validate a carrier manifest from PNG metadata."
+    )
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--field", default="Comment")
+    parser.add_argument(
+        "--manifest-only",
+        action="store_true",
+        help="Print only the extracted manifest JSON.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.manifest_only:
+            manifest = extract_carrier_manifest_from_image(args.image, args.field)
+            print(json.dumps(manifest, sort_keys=True))
+            return 0
+
+        result = validate_membrane_image(args.image, args.field)
+    except (OSError, ValueError, json.JSONDecodeError, zlib.error) as exc:
+        result = {"valid": False, "errors": [f"failed to extract manifest: {exc}"]}
+
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_membrane_tool.py
+++ b/tests/test_membrane_tool.py
@@ -1,0 +1,123 @@
+import json
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+from eve_q.membrane_tool import (
+    extract_carrier_manifest_from_image,
+    validate_membrane_image,
+)
+
+MANIFEST_PATH = Path("examples/artifact_carrier_manifest.example.json")
+
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def png_chunk(chunk_type, data):
+    crc = zlib.crc32(chunk_type + data) & 0xFFFFFFFF
+    return len(data).to_bytes(4, "big") + chunk_type + data + crc.to_bytes(4, "big")
+
+
+def write_png_with_comment(path, comment):
+    ihdr = (1).to_bytes(4, "big") + (1).to_bytes(4, "big") + bytes([8, 2, 0, 0, 0])
+    text = b"Comment\x00" + comment.encode("latin-1")
+    path.write_bytes(
+        PNG_SIGNATURE
+        + png_chunk(b"IHDR", ihdr)
+        + png_chunk(b"tEXt", text)
+        + png_chunk(b"IEND", b"")
+    )
+
+
+def run_cli(image_path, *extra_args):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.membrane_tool",
+            "--image",
+            str(image_path),
+            *extra_args,
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_extract_carrier_manifest_from_png_comment(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    extracted = extract_carrier_manifest_from_image(image)
+
+    assert extracted == manifest
+
+
+def test_validate_membrane_image_accepts_valid_manifest(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    result = validate_membrane_image(image)
+
+    assert result["valid"] is True
+    assert result["errors"] == []
+    assert result["metadata_field"] == "Comment"
+    assert result["manifest"] == manifest
+
+
+def test_membrane_tool_cli_validates_png_comment_manifest(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    result = run_cli(image)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert payload["valid"] is True
+    assert payload["errors"] == []
+    assert payload["manifest"] == manifest
+    assert result.stderr == ""
+
+
+def test_membrane_tool_cli_manifest_only(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    result = run_cli(image, "--manifest-only")
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == manifest
+
+
+def test_membrane_tool_cli_rejects_invalid_manifest(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    manifest["execution_authority"] = "scheduler"
+
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    result = run_cli(image)
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert any("execution_authority must be none" in error for error in payload["errors"])
+
+
+def test_membrane_tool_cli_reports_missing_comment(tmp_path):
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, "{}")
+
+    result = run_cli(image, "--field", "Missing")
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert payload["errors"][0].startswith("failed to extract manifest:")


### PR DESCRIPTION
Adds a pure local membrane metadata extractor.

Scope:
- adds python -m eve_q.membrane_tool
- extracts carrier manifest JSON from PNG Comment metadata
- validates extracted manifests against the artifact carrier law
- supports manifest-only extraction
- reports missing metadata fields
- reports invalid manifests
- adds extractor tests
- adds CI coverage for membrane tool surfaces

Safety boundary:
- extract only
- parse only
- validate only
- no IPFS daemon dependency
- no metadata writing
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The image carries the acorn.
The extractor reads.
The validator judges.
The artifact still does not command.