### PR TITLE
Add membrane tool to README surface index

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,12 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | Receipt carrier attestation validator | `eve_q/receipt_carrier_attestation.py` | Binds a receipt identifier to a carrier manifest digest and CID as a review artifact. |
 | Receipt carrier attestation example | `examples/receipt_carrier_attestation.example.json` | Demonstrates safe receipt-to-carrier attestation. |
 | Receipt carrier attestation docs | `docs/receipt_carrier_attestation_example.md` | Documents attestation drift detection and non-execution boundaries. |
+| Membrane metadata extractor | `eve_q/membrane_tool.py` | Extracts carrier manifests from PNG Comment metadata and validates them without execution authority. |
 
 Current law:
 
 ```text
+Image carries acorn.
 Receipt remembers.
 Carrier points.
 Hash detects drift.
@@ -127,5 +129,6 @@ Safety boundary:
 - no reverse execution channel
 - no IPFS daemon dependency for validation
 - no image metadata dependency for validation
+- no metadata writing
 
 <!-- constitutional-surfaces-index:end -->

--- a/tests/test_readme_constitutional_surface_index.py
+++ b/tests/test_readme_constitutional_surface_index.py
@@ -14,6 +14,7 @@ def test_readme_names_current_constitutional_surfaces():
         "eve_q/receipt_carrier_attestation.py",
         "examples/receipt_carrier_attestation.example.json",
         "docs/receipt_carrier_attestation_example.md",
+        "eve_q/membrane_tool.py",
     ]
 
     for item in required:
@@ -28,7 +29,9 @@ def test_readme_preserves_non_execution_boundary():
         "no wallet signing",
         "no scheduler authority",
         "no reverse execution channel",
+        "no metadata writing",
         "Human promotes.",
+        "Image carries acorn.",
     ]
 
     for item in required:


### PR DESCRIPTION
Adds the membrane metadata extractor to the public README constitutional surface index.

Scope:
- lists eve_q/membrane_tool.py in the README surface map
- records the image-carried acorn law
- preserves the non-execution and no-metadata-writing boundary
- updates the README guard test

Safety boundary:
- documentation and tests only
- no runtime behavior changes
- no IPFS daemon dependency
- no metadata writing
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The README names the membrane.
The test guards the map.
The artifact still does not command.