### PR TITLE
Add membrane tool usage docs

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -29,6 +29,8 @@ on:
       - 'tests/test_receipt_carrier_attestation_cli.py'
       - 'tests/test_artifact_carrier_cli.py'
       - 'tests/test_membrane_tool.py'
+      - 'tests/test_membrane_tool_usage_docs.py'
+      - 'docs/membrane_tool_usage.md'
       - 'eve_q/membrane_tool.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
@@ -121,6 +123,7 @@ jobs:
           tests/test_receipt_carrier_attestation_cli.py \
           tests/test_artifact_carrier_cli.py \
           tests/test_membrane_tool.py \
+          tests/test_membrane_tool_usage_docs.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,8 @@ on:
       - 'tests/test_receipt_carrier_attestation_cli.py'
       - 'tests/test_artifact_carrier_cli.py'
       - 'tests/test_membrane_tool.py'
+      - 'tests/test_membrane_tool_usage_docs.py'
+      - 'docs/membrane_tool_usage.md'
       - 'eve_q/membrane_tool.py'
       - 'README.md'
       - 'examples/receipt_carrier_attestation.example.json'
@@ -121,6 +123,7 @@ jobs:
           tests/test_receipt_carrier_attestation_cli.py \
           tests/test_artifact_carrier_cli.py \
           tests/test_membrane_tool.py \
+          tests/test_membrane_tool_usage_docs.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/docs/membrane_tool_usage.md
+++ b/docs/membrane_tool_usage.md
@@ -1,0 +1,87 @@
+# Membrane Tool Usage
+
+The membrane tool extracts a carrier manifest from PNG metadata and validates it against the artifact carrier law.
+
+It is intentionally read-only.
+
+## Safety Boundary
+
+- extract only
+- parse only
+- validate only
+- no metadata writing
+- no IPFS daemon dependency
+- no network access
+- no wallet access
+- no scheduler
+- no capital movement
+
+## Validate A Membrane Image
+
+```bash
+python -m eve_q.membrane_tool \
+  --image ~/spiral_membrane_sealed.png
+```
+
+Expected shape:
+
+```json
+{"valid": true, "errors": []}
+```
+
+The actual output also includes the extracted manifest and metadata field name.
+
+## Extract Manifest Only
+
+```bash
+python -m eve_q.membrane_tool \
+  --image ~/spiral_membrane_sealed.png \
+  --manifest-only
+```
+
+This prints only the JSON manifest embedded in the PNG Comment metadata field.
+
+## Validate A Carrier Manifest Directly
+
+```bash
+python -m eve_q.artifact_carrier \
+  --manifest examples/artifact_carrier_manifest.example.json
+```
+
+## Validate Receipt-To-Carrier Attestation
+
+```bash
+python -m eve_q.receipt_carrier_attestation \
+  --carrier examples/artifact_carrier_manifest.example.json \
+  --attestation examples/receipt_carrier_attestation.example.json
+```
+
+## The Self-CID Trap
+
+An IPFS CID is derived from the full file contents.
+
+That means an image cannot safely contain its own final CID inside its own metadata.
+
+If the final CID is embedded back into the image, the image bytes change, which changes the CID again.
+
+Therefore the safe pattern is:
+
+```text
+image metadata -> carrier manifest
+carrier manifest -> payload CID or receipt CID
+receipt attestation -> carrier manifest hash and carrier CID
+```
+
+The embedded manifest should point to a payload, receipt, or encrypted spore pointer.
+
+It should not try to self-seal the image by containing the image's own final CID.
+
+## Law
+
+```text
+The image carries the acorn.
+The extractor reads.
+The validator judges.
+The operator remembers the self-CID trap.
+The artifact still does not command.
+```

--- a/tests/test_membrane_tool_usage_docs.py
+++ b/tests/test_membrane_tool_usage_docs.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+DOC = Path("docs/membrane_tool_usage.md")
+
+
+def test_membrane_tool_usage_doc_names_cli_surfaces():
+    text = DOC.read_text()
+
+    required = [
+        "python -m eve_q.membrane_tool",
+        "python -m eve_q.artifact_carrier",
+        "python -m eve_q.receipt_carrier_attestation",
+        "--manifest-only",
+    ]
+
+    for item in required:
+        assert item in text
+
+
+def test_membrane_tool_usage_doc_preserves_safety_boundary():
+    text = DOC.read_text()
+
+    required = [
+        "extract only",
+        "parse only",
+        "validate only",
+        "no metadata writing",
+        "no IPFS daemon dependency",
+        "no network access",
+        "no wallet access",
+        "no scheduler",
+        "no capital movement",
+    ]
+
+    for item in required:
+        assert item in text
+
+
+def test_membrane_tool_usage_doc_explains_self_cid_trap():
+    text = DOC.read_text()
+
+    required = [
+        "The Self-CID Trap",
+        "An IPFS CID is derived from the full file contents.",
+        "the image bytes change",
+        "changes the CID again",
+        "should not try to self-seal the image",
+    ]
+
+    for item in required:
+        assert item in text
+
+
+def test_membrane_tool_usage_doc_preserves_law():
+    text = DOC.read_text()
+
+    required = [
+        "The image carries the acorn.",
+        "The extractor reads.",
+        "The validator judges.",
+        "The operator remembers the self-CID trap.",
+        "The artifact still does not command.",
+    ]
+
+    for item in required:
+        assert item in text


### PR DESCRIPTION
Adds operator usage documentation for the membrane metadata extractor.

Scope:
- documents python -m eve_q.membrane_tool
- documents manifest-only extraction
- documents direct artifact carrier validation
- documents receipt-to-carrier attestation validation
- explains the IPFS self-CID trap
- preserves extract-only, parse-only, validate-only boundaries
- adds doc guard tests
- adds CI coverage for the usage docs

Safety boundary:
- documentation and tests only
- no runtime behavior changes
- no IPFS daemon dependency
- no metadata writing
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The tool exists.
The docs teach.
The operator remembers the trap.
The artifact still does not command.