### PR TITLE
Add membrane attestation bridge

### DIFF
--- a/docs/membrane_tool_usage.md
+++ b/docs/membrane_tool_usage.md
@@ -31,6 +31,17 @@ Expected shape:
 
 The actual output also includes the extracted manifest and metadata field name.
 
+## Validate Membrane Image With Receipt Attestation
+
+```bash
+python -m eve_q.membrane_tool \
+  --image ~/spiral_membrane_sealed.png \
+  --attestation examples/receipt_carrier_attestation.example.json
+```
+
+This extracts the carrier manifest from the image, validates the carrier law, then validates the receipt-to-carrier attestation against the extracted manifest.
+
+The bridge is still read-only.
 ## Extract Manifest Only
 
 ```bash

--- a/eve_q/membrane_tool.py
+++ b/eve_q/membrane_tool.py
@@ -21,6 +21,10 @@ from pathlib import Path
 from typing import Any
 
 from eve_q.artifact_carrier import validate_artifact_carrier_manifest
+from eve_q.receipt_carrier_attestation import (
+    load_json,
+    validate_receipt_carrier_attestation,
+)
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -127,17 +131,35 @@ def extract_carrier_manifest_from_image(
 def validate_membrane_image(
     image_path: Path | str,
     field_name: str = "Comment",
+    attestation_path: Path | str | None = None,
 ) -> dict[str, Any]:
     """Extract and validate an image-carried artifact carrier manifest."""
     manifest = extract_carrier_manifest_from_image(image_path, field_name)
-    errors = validate_artifact_carrier_manifest(manifest)
+    carrier_errors = validate_artifact_carrier_manifest(manifest)
 
-    return {
-        "valid": errors == [],
-        "errors": errors,
+    result: dict[str, Any] = {
+        "valid": carrier_errors == [],
+        "errors": carrier_errors,
         "metadata_field": field_name,
         "manifest": manifest,
     }
+
+    if attestation_path is not None:
+        attestation = load_json(attestation_path)
+        attestation_errors = validate_receipt_carrier_attestation(
+            attestation,
+            manifest,
+        )
+        result["attestation"] = {
+            "valid": attestation_errors == [],
+            "errors": attestation_errors,
+        }
+        result["valid"] = result["valid"] and attestation_errors == []
+        result["errors"] = carrier_errors + [
+            f"attestation: {error}" for error in attestation_errors
+        ]
+
+    return result
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -147,6 +169,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--image", required=True)
     parser.add_argument("--field", default="Comment")
+    parser.add_argument("--attestation")
     parser.add_argument(
         "--manifest-only",
         action="store_true",
@@ -160,9 +183,13 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps(manifest, sort_keys=True))
             return 0
 
-        result = validate_membrane_image(args.image, args.field)
+        result = validate_membrane_image(
+            args.image,
+            args.field,
+            args.attestation,
+        )
     except (OSError, ValueError, json.JSONDecodeError, zlib.error) as exc:
-        result = {"valid": False, "errors": [f"failed to extract manifest: {exc}"]}
+        result = {"valid": False, "errors": [f"failed to validate membrane: {exc}"]}
 
     print(json.dumps(result, sort_keys=True))
     return 0 if result["valid"] else 1

--- a/tests/test_membrane_tool.py
+++ b/tests/test_membrane_tool.py
@@ -10,6 +10,7 @@ from eve_q.membrane_tool import (
 )
 
 MANIFEST_PATH = Path("examples/artifact_carrier_manifest.example.json")
+ATTESTATION_PATH = Path("examples/receipt_carrier_attestation.example.json")
 
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -120,4 +121,50 @@ def test_membrane_tool_cli_reports_missing_comment(tmp_path):
 
     assert result.returncode == 1
     assert payload["valid"] is False
-    assert payload["errors"][0].startswith("failed to extract manifest:")
+    assert payload["errors"][0].startswith("failed to validate membrane:")
+
+
+def test_validate_membrane_image_accepts_receipt_attestation(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    result = validate_membrane_image(
+        image,
+        attestation_path=ATTESTATION_PATH,
+    )
+
+    assert result["valid"] is True
+    assert result["errors"] == []
+    assert result["attestation"] == {"valid": True, "errors": []}
+
+
+def test_membrane_tool_cli_validates_receipt_attestation(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    result = run_cli(image, "--attestation", str(ATTESTATION_PATH))
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert payload["valid"] is True
+    assert payload["attestation"] == {"valid": True, "errors": []}
+
+
+def test_membrane_tool_cli_rejects_attestation_drift(tmp_path):
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    manifest["payload_type"] = "changed_payload"
+
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(manifest))
+
+    result = run_cli(image, "--attestation", str(ATTESTATION_PATH))
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert payload["attestation"]["valid"] is False
+    assert any(
+        "carrier_manifest_sha256 mismatch" in error for error in payload["attestation"]["errors"]
+    )

--- a/tests/test_membrane_tool_usage_docs.py
+++ b/tests/test_membrane_tool_usage_docs.py
@@ -11,6 +11,7 @@ def test_membrane_tool_usage_doc_names_cli_surfaces():
         "python -m eve_q.artifact_carrier",
         "python -m eve_q.receipt_carrier_attestation",
         "--manifest-only",
+        "--attestation",
     ]
 
     for item in required:
@@ -24,6 +25,7 @@ def test_membrane_tool_usage_doc_preserves_safety_boundary():
         "extract only",
         "parse only",
         "validate only",
+        "The bridge is still read-only.",
         "no metadata writing",
         "no IPFS daemon dependency",
         "no network access",


### PR DESCRIPTION
Adds optional receipt attestation validation to the membrane metadata extractor.

Scope:
- adds --attestation to python -m eve_q.membrane_tool
- extracts carrier manifest from image metadata
- validates the extracted carrier manifest
- validates receipt-to-carrier attestation against the extracted manifest
- detects attestation drift
- updates usage docs
- adds bridge tests

Safety boundary:
- extract only
- parse only
- validate only
- no metadata writing
- no IPFS daemon dependency
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The image carries.
The attestation binds.
The validator compares.
The artifact still does not command.