### PR TITLE
Add membrane attestation bridge to README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,23 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | Receipt carrier attestation validator | `eve_q/receipt_carrier_attestation.py` | Binds a receipt identifier to a carrier manifest digest and CID as a review artifact. |
 | Receipt carrier attestation example | `examples/receipt_carrier_attestation.example.json` | Demonstrates safe receipt-to-carrier attestation. |
 | Receipt carrier attestation docs | `docs/receipt_carrier_attestation_example.md` | Documents attestation drift detection and non-execution boundaries. |
-| Membrane metadata extractor | `eve_q/membrane_tool.py` | Extracts carrier manifests from PNG Comment metadata and validates them without execution authority. |
+| Membrane metadata extractor and attestation bridge | `eve_q/membrane_tool.py` | Extracts carrier manifests from PNG Comment metadata, validates carrier law, and can compare receipt attestations without execution authority. |
 
+
+Membrane bridge:
+
+`python -m eve_q.membrane_tool --image <png> --attestation <attestation.json>`
+
+Chain:
+
+`image metadata -> carrier manifest -> receipt attestation -> validation result`
 Current law:
 
 ```text
 Image carries acorn.
+The validator compares.
+The attestation binds.
+The image carries.
 Receipt remembers.
 Carrier points.
 Hash detects drift.

--- a/tests/test_readme_constitutional_surface_index.py
+++ b/tests/test_readme_constitutional_surface_index.py
@@ -15,6 +15,7 @@ def test_readme_names_current_constitutional_surfaces():
         "examples/receipt_carrier_attestation.example.json",
         "docs/receipt_carrier_attestation_example.md",
         "eve_q/membrane_tool.py",
+        "Membrane metadata extractor and attestation bridge",
     ]
 
     for item in required:
@@ -32,6 +33,10 @@ def test_readme_preserves_non_execution_boundary():
         "no metadata writing",
         "Human promotes.",
         "Image carries acorn.",
+        "The validator compares.",
+        "The attestation binds.",
+        "image metadata -> carrier manifest -> receipt attestation -> validation result",
+        "--attestation",
     ]
 
     for item in required:


### PR DESCRIPTION
Adds the membrane attestation bridge to the public README constitutional surface index.

Scope:
- updates the membrane tool README row
- documents the --attestation bridge command shape
- records image metadata -> carrier manifest -> receipt attestation -> validation result
- preserves the non-execution boundary through README guard tests

Safety boundary:
- documentation and tests only
- no runtime behavior changes
- no metadata writing
- no IPFS daemon dependency
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The image carries.
The attestation binds.
The validator compares.
The artifact still does not command.