### PR TITLE
Add constitutional release audit

### DIFF
--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -31,6 +31,8 @@ on:
       - 'tests/test_membrane_tool.py'
       - 'tests/test_membrane_tool_usage_docs.py'
       - 'tests/test_constitutional_membrane_checkpoint.py'
+      - 'tests/test_constitutional_release_audit.py'
+      - 'docs/constitutional_release_audit.md'
       - 'docs/constitutional_membrane_checkpoint.md'
       - 'docs/membrane_tool_usage.md'
       - 'eve_q/membrane_tool.py'
@@ -127,6 +129,7 @@ jobs:
           tests/test_membrane_tool.py \
           tests/test_membrane_tool_usage_docs.py \
           tests/test_constitutional_membrane_checkpoint.py \
+          tests/test_constitutional_release_audit.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,8 @@ on:
       - 'tests/test_membrane_tool.py'
       - 'tests/test_membrane_tool_usage_docs.py'
       - 'tests/test_constitutional_membrane_checkpoint.py'
+      - 'tests/test_constitutional_release_audit.py'
+      - 'docs/constitutional_release_audit.md'
       - 'docs/constitutional_membrane_checkpoint.md'
       - 'docs/membrane_tool_usage.md'
       - 'eve_q/membrane_tool.py'
@@ -127,6 +129,7 @@ jobs:
           tests/test_membrane_tool.py \
           tests/test_membrane_tool_usage_docs.py \
           tests/test_constitutional_membrane_checkpoint.py \
+          tests/test_constitutional_release_audit.py \
             tests/test_charity_allocation_diversity_guard.py \
             tests/test_need_impact_scoring.py
 

--- a/docs/constitutional_release_audit.md
+++ b/docs/constitutional_release_audit.md
@@ -1,0 +1,81 @@
+# Constitutional Release Audit
+
+This audit records release readiness for the constitutional membrane layer.
+
+It verifies that the current carrier, attestation, CLI, README, checkpoint, and membrane surfaces remain simulation-first, review-only, and non-executing.
+
+## Audited Surface Stack
+
+| Surface | File | Audit Meaning |
+| --- | --- | --- |
+| Artifact carrier validator | `eve_q/artifact_carrier.py` | Validates carrier manifests from Python and shell. |
+| Artifact carrier example | `examples/artifact_carrier_manifest.example.json` | Deterministic teaching manifest. |
+| Receipt carrier attestation validator | `eve_q/receipt_carrier_attestation.py` | Validates receipt-to-carrier bindings. |
+| Receipt carrier attestation example | `examples/receipt_carrier_attestation.example.json` | Deterministic attestation example. |
+| Membrane metadata extractor | `eve_q/membrane_tool.py` | Extracts image-carried manifests and validates them. |
+| Membrane usage docs | `docs/membrane_tool_usage.md` | Teaches safe operator usage and the self-CID trap. |
+| Constitutional checkpoint | `docs/constitutional_membrane_checkpoint.md` | Records PR #20 through PR #33 membrane history. |
+| README surface index | `README.md` | Publicly names the active constitutional surfaces. |
+
+## Release Smoke Commands
+
+```bash
+python -m eve_q.artifact_carrier \
+  --manifest examples/artifact_carrier_manifest.example.json
+
+python -m eve_q.receipt_carrier_attestation \
+  --carrier examples/artifact_carrier_manifest.example.json \
+  --attestation examples/receipt_carrier_attestation.example.json
+
+python -m eve_q.membrane_tool \
+  --image ~/spiral_membrane_sealed.png \
+  --attestation examples/receipt_carrier_attestation.example.json
+```
+
+Expected result: all commands report `valid: true`.
+
+## Release Boundary
+
+- no autonomous capital movement
+- no wallet signing
+- no scheduler authority
+- no reverse execution channel
+- no metadata writing
+- no IPFS daemon dependency
+- no network access
+- no shell execution from metadata
+- no subprocess execution from metadata
+- no command execution from metadata
+
+## Example Authority Requirements
+
+The deterministic example artifacts must preserve:
+
+- `execution_authority: none`
+- `human_promotion_required: true`
+- `reverse_execution_channel_opened: false`
+- `ttl_mode: artifact_only`
+
+## Self-CID Trap
+
+An image cannot safely contain its own final CID inside its own metadata.
+
+Embedding the CID changes the image bytes, which changes the CID again.
+
+Safe pattern:
+
+```text
+image metadata -> carrier manifest
+carrier manifest -> payload CID or receipt CID
+receipt attestation -> carrier manifest hash and carrier CID
+```
+
+## Release Law
+
+```text
+The validators answer.
+The CLIs report.
+The docs remember.
+The release audit seals the membrane.
+The artifact still does not command.
+```

--- a/tests/test_constitutional_release_audit.py
+++ b/tests/test_constitutional_release_audit.py
@@ -1,0 +1,174 @@
+import json
+import subprocess
+import sys
+import zlib
+from pathlib import Path
+
+DOC = Path("docs/constitutional_release_audit.md")
+README = Path("README.md")
+CHECKPOINT = Path("docs/constitutional_membrane_checkpoint.md")
+CARRIER = Path("examples/artifact_carrier_manifest.example.json")
+ATTESTATION = Path("examples/receipt_carrier_attestation.example.json")
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def png_chunk(chunk_type, data):
+    crc = zlib.crc32(chunk_type + data) & 0xFFFFFFFF
+    return len(data).to_bytes(4, "big") + chunk_type + data + crc.to_bytes(4, "big")
+
+
+def write_png_with_comment(path, comment):
+    ihdr = (1).to_bytes(4, "big") + (1).to_bytes(4, "big") + bytes([8, 2, 0, 0, 0])
+    text = b"Comment\x00" + comment.encode("latin-1")
+    path.write_bytes(
+        PNG_SIGNATURE
+        + png_chunk(b"IHDR", ihdr)
+        + png_chunk(b"tEXt", text)
+        + png_chunk(b"IEND", b"")
+    )
+
+
+def run_command(args):
+    return subprocess.run(
+        [sys.executable, "-m", *args],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_release_audit_doc_names_current_surfaces():
+    text = DOC.read_text()
+
+    required = [
+        "eve_q/artifact_carrier.py",
+        "examples/artifact_carrier_manifest.example.json",
+        "eve_q/receipt_carrier_attestation.py",
+        "examples/receipt_carrier_attestation.example.json",
+        "eve_q/membrane_tool.py",
+        "docs/membrane_tool_usage.md",
+        "docs/constitutional_membrane_checkpoint.md",
+        "README.md",
+    ]
+
+    for item in required:
+        assert item in text
+
+
+def test_release_audit_preserves_boundary_language():
+    text = "\n".join(
+        [
+            DOC.read_text(),
+            README.read_text(),
+            CHECKPOINT.read_text(),
+        ]
+    )
+
+    required = [
+        "no autonomous capital movement",
+        "no wallet signing",
+        "no scheduler authority",
+        "no reverse execution channel",
+        "no metadata writing",
+        "no IPFS daemon dependency",
+        "no network access",
+        "no command execution from metadata",
+    ]
+
+    for item in required:
+        assert item in text
+
+
+def test_release_examples_preserve_non_authority_flags():
+    carrier = json.loads(CARRIER.read_text())
+    attestation = json.loads(ATTESTATION.read_text())
+
+    for artifact in [carrier, attestation]:
+        assert artifact["execution_authority"] == "none"
+        assert artifact["human_promotion_required"] is True
+        assert artifact["reverse_execution_channel_opened"] is False
+        assert artifact["ttl_mode"] == "artifact_only"
+
+
+def test_release_artifact_carrier_cli_smoke():
+    result = run_command(
+        [
+            "eve_q.artifact_carrier",
+            "--manifest",
+            str(CARRIER),
+        ]
+    )
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {"errors": [], "valid": True}
+    assert result.stderr == ""
+
+
+def test_release_receipt_attestation_cli_smoke():
+    result = run_command(
+        [
+            "eve_q.receipt_carrier_attestation",
+            "--carrier",
+            str(CARRIER),
+            "--attestation",
+            str(ATTESTATION),
+        ]
+    )
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {"errors": [], "valid": True}
+    assert result.stderr == ""
+
+
+def test_release_membrane_bridge_cli_smoke(tmp_path):
+    carrier = json.loads(CARRIER.read_text())
+    image = tmp_path / "membrane.png"
+    write_png_with_comment(image, json.dumps(carrier))
+
+    result = run_command(
+        [
+            "eve_q.membrane_tool",
+            "--image",
+            str(image),
+            "--attestation",
+            str(ATTESTATION),
+        ]
+    )
+    payload = json.loads(result.stdout)
+
+    assert result.returncode == 0
+    assert payload["valid"] is True
+    assert payload["errors"] == []
+    assert payload["attestation"] == {"errors": [], "valid": True}
+    assert result.stderr == ""
+
+
+def test_release_audit_preserves_self_cid_trap():
+    text = DOC.read_text()
+
+    required = [
+        "Self-CID Trap",
+        "An image cannot safely contain its own final CID",
+        "Embedding the CID changes the image bytes",
+        "changes the CID again",
+        "image metadata -> carrier manifest",
+    ]
+
+    for item in required:
+        assert item in text
+
+
+def test_release_audit_preserves_law():
+    text = DOC.read_text()
+
+    required = [
+        "The validators answer.",
+        "The CLIs report.",
+        "The docs remember.",
+        "The release audit seals the membrane.",
+        "The artifact still does not command.",
+    ]
+
+    for item in required:
+        assert item in text


### PR DESCRIPTION
Adds a release-readiness audit for the constitutional membrane.

Scope:
- documents audited membrane surfaces
- records release smoke commands
- verifies artifact carrier CLI
- verifies receipt carrier attestation CLI
- verifies membrane bridge CLI
- verifies non-authority flags on deterministic examples
- preserves the self-CID trap
- preserves the explicit non-authority boundary
- adds release audit tests
- adds CI coverage for the audit

Safety boundary:
- documentation and tests only
- no runtime behavior changes
- no metadata writing
- no IPFS daemon dependency
- no network access
- no wallet access
- no scheduler
- no capital movement

Law:
The validators answer.
The CLIs report.
The docs remember.
The release audit seals the membrane.
The artifact still does not command.