### PR TITLE
Add immutable receipt gate

### DIFF
--- a/eve_q/immutable_receipts.py
+++ b/eve_q/immutable_receipts.py
@@ -1,0 +1,237 @@
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+RECEIPT_SCHEMA = "eve_q.immutable_receipt.v0.1"
+RECEIPT_VERSION = "0.1.0"
+MOCK_CID_PREFIX = "mock-ipfs-"
+
+COMPLETE_STATUSES = {
+    "SETTLED",
+    "COMPLETE",
+}
+
+FORBIDDEN_FIELDS = {
+    "api_key",
+    "command",
+    "mnemonic",
+    "password",
+    "private_key",
+    "scheduler",
+    "secret",
+    "seed_phrase",
+    "shell",
+    "subprocess",
+    "wallet_private_key",
+    "webhook_url",
+}
+
+
+class ReceiptSealError(RuntimeError):
+    pass
+
+
+def canonical_json_bytes(value: dict[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def forbidden_paths(
+    value: Any,
+    forbidden: set[str] = FORBIDDEN_FIELDS,
+    path: str = "$",
+) -> list[str]:
+    found = []
+
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+
+            if key in forbidden:
+                found.append(child_path)
+
+            found.extend(forbidden_paths(child, forbidden, child_path))
+
+    if isinstance(value, list):
+        for index, child in enumerate(value):
+            child_path = f"{path}[{index}]"
+            found.extend(forbidden_paths(child, forbidden, child_path))
+
+    return found
+
+
+def validate_receipt_payload(receipt: dict[str, Any]) -> None:
+    receipt_type = receipt.get("receipt_type")
+
+    if not receipt_type:
+        raise ReceiptSealError("receipt_type is required")
+
+    forbidden = forbidden_paths(receipt)
+
+    if forbidden:
+        joined = ", ".join(forbidden)
+        raise ReceiptSealError(f"forbidden receipt fields present: {joined}")
+
+
+def envelope_digest(envelope: dict[str, Any]) -> str:
+    digest_source = dict(envelope)
+    digest_source.pop("local_sha256", None)
+
+    return sha256_hex(canonical_json_bytes(digest_source))
+
+
+def build_receipt_envelope(
+    receipt: dict[str, Any],
+    previous_cid: str | None = None,
+) -> dict[str, Any]:
+    validate_receipt_payload(receipt)
+
+    envelope = {
+        "schema": RECEIPT_SCHEMA,
+        "version": RECEIPT_VERSION,
+        "receipt": receipt,
+        "previous_cid": previous_cid,
+        "execution_authority": "none",
+        "artifact_is_command": False,
+        "may_execute": False,
+        "may_move_capital": False,
+        "human_promotion_required": True,
+    }
+
+    envelope["local_sha256"] = envelope_digest(envelope)
+    return envelope
+
+
+class InMemoryIpfsWriter:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.pins: set[str] = set()
+
+    def add_and_pin(self, data: bytes) -> str:
+        cid = MOCK_CID_PREFIX + sha256_hex(data)
+        self.objects[cid] = data
+        self.pins.add(cid)
+
+        return cid
+
+    def cat(self, cid: str) -> bytes:
+        return self.objects[cid]
+
+    def is_pinned(self, cid: str) -> bool:
+        return cid in self.pins
+
+
+class JsonlReceiptLedger:
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def read_events(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+
+        events = []
+
+        for line in self.path.read_text().splitlines():
+            if line.strip():
+                events.append(json.loads(line))
+
+        return events
+
+    def append_event(self, event: dict[str, Any]) -> dict[str, Any]:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+        events = self.read_events()
+        sequence = len(events) + 1
+
+        entry = {
+            "sequence": sequence,
+            **event,
+        }
+
+        with self.path.open("a") as handle:
+            handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+        return entry
+
+
+def seal_receipt(
+    receipt: dict[str, Any],
+    previous_cid: str | None,
+    ipfs: InMemoryIpfsWriter,
+    ledger: JsonlReceiptLedger,
+) -> dict[str, Any]:
+    envelope = build_receipt_envelope(receipt, previous_cid)
+    data = canonical_json_bytes(envelope)
+
+    cid = ipfs.add_and_pin(data)
+
+    if not ipfs.is_pinned(cid):
+        raise ReceiptSealError("receipt CID was not pinned")
+
+    resolved = ipfs.cat(cid)
+
+    if resolved != data:
+        raise ReceiptSealError("IPFS CID verification failed")
+
+    event = ledger.append_event(
+        {
+            "event_type": "receipt_pinned",
+            "cid": cid,
+            "local_sha256": sha256_hex(data),
+            "envelope_sha256": envelope["local_sha256"],
+            "previous_cid": previous_cid,
+            "receipt_type": receipt["receipt_type"],
+            "execution_authority": "none",
+            "artifact_is_command": False,
+            "may_execute": False,
+            "may_move_capital": False,
+        }
+    )
+
+    return {
+        "status": "IPFS_PINNED_VERIFIED",
+        "cid": cid,
+        "local_sha256": sha256_hex(data),
+        "envelope_sha256": envelope["local_sha256"],
+        "envelope": envelope,
+        "ledger_event": event,
+    }
+
+
+def require_receipt_cid_for_completion(
+    action_kind: str,
+    target_status: str,
+    receipt_cid: str | None,
+) -> bool:
+    if target_status in COMPLETE_STATUSES and not receipt_cid:
+        raise ReceiptSealError(
+            f"{action_kind} cannot reach {target_status} " "without verified receipt CID"
+        )
+
+    return True
+
+
+def mark_action_complete(
+    action_kind: str,
+    receipt_cid: str | None,
+    target_status: str = "COMPLETE",
+) -> dict[str, str]:
+    require_receipt_cid_for_completion(
+        action_kind,
+        target_status,
+        receipt_cid,
+    )
+
+    return {
+        "action_kind": action_kind,
+        "status": target_status,
+        "receipt_cid": str(receipt_cid),
+    }

--- a/tests/test_immutable_receipts.py
+++ b/tests/test_immutable_receipts.py
@@ -1,0 +1,202 @@
+import pytest
+
+from eve_q.immutable_receipts import (
+    InMemoryIpfsWriter,
+    JsonlReceiptLedger,
+    ReceiptSealError,
+    build_receipt_envelope,
+    canonical_json_bytes,
+    envelope_digest,
+    mark_action_complete,
+    seal_receipt,
+)
+
+
+def trade_receipt():
+    return {
+        "receipt_type": "TradeReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "strategy_id": "eve_q.shadow_v0",
+        "order_intent_hash": "sha256:intent",
+        "risk_report_hash": "sha256:risk",
+        "human_approval_hash": "sha256:approval",
+        "execution_result_hash": "sha256:execution",
+        "profit_loss": "0.00",
+        "charity_allocation_rule": "15_percent_positive_profit",
+    }
+
+
+def charity_receipt(source_trade_cid):
+    return {
+        "receipt_type": "CharityTxReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "source_trade_receipt_cid": source_trade_cid,
+        "charity_policy_id": "charity_geodesic_v0",
+        "recipient_id_hash": "sha256:recipient",
+        "amount": "0.00",
+        "currency": "USD",
+        "tx_ref_hash": "sha256:txref",
+        "verification_status": "simulated",
+    }
+
+
+def test_canonical_json_bytes_are_deterministic():
+    first = canonical_json_bytes({"b": 2, "a": 1})
+    second = canonical_json_bytes({"a": 1, "b": 2})
+
+    assert first == second
+
+
+def test_receipt_envelope_preserves_non_authority_flags():
+    envelope = build_receipt_envelope(trade_receipt())
+
+    assert envelope["execution_authority"] == "none"
+    assert envelope["artifact_is_command"] is False
+    assert envelope["may_execute"] is False
+    assert envelope["may_move_capital"] is False
+    assert envelope["human_promotion_required"] is True
+    assert envelope["local_sha256"] == envelope_digest(envelope)
+
+
+def test_trade_receipt_seals_to_pinned_verified_cid(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger = JsonlReceiptLedger(tmp_path / "receipt_ledger.jsonl")
+
+    result = seal_receipt(
+        trade_receipt(),
+        previous_cid=None,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    assert result["status"] == "IPFS_PINNED_VERIFIED"
+    assert result["cid"].startswith("mock-ipfs-")
+    assert ipfs.is_pinned(result["cid"])
+
+    events = ledger.read_events()
+    assert len(events) == 1
+    assert events[0]["event_type"] == "receipt_pinned"
+    assert events[0]["receipt_type"] == "TradeReceipt"
+    assert events[0]["cid"] == result["cid"]
+
+
+def test_charity_receipt_links_to_trade_receipt_cid(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger = JsonlReceiptLedger(tmp_path / "receipt_ledger.jsonl")
+
+    trade = seal_receipt(
+        trade_receipt(),
+        previous_cid=None,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+    charity = seal_receipt(
+        charity_receipt(trade["cid"]),
+        previous_cid=trade["cid"],
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    assert charity["envelope"]["previous_cid"] == trade["cid"]
+    assert charity["envelope"]["receipt"]["source_trade_receipt_cid"]
+    assert charity["cid"] != trade["cid"]
+
+    events = ledger.read_events()
+    assert len(events) == 2
+    assert events[1]["previous_cid"] == trade["cid"]
+
+
+def test_forbidden_secret_fields_are_rejected_before_sealing(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger = JsonlReceiptLedger(tmp_path / "receipt_ledger.jsonl")
+    receipt = trade_receipt()
+    receipt["wallet_private_key"] = "do-not-store"
+
+    with pytest.raises(ReceiptSealError):
+        seal_receipt(
+            receipt,
+            previous_cid=None,
+            ipfs=ipfs,
+            ledger=ledger,
+        )
+
+    assert ledger.read_events() == []
+
+
+def test_nested_forbidden_command_field_is_rejected(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger = JsonlReceiptLedger(tmp_path / "receipt_ledger.jsonl")
+    receipt = trade_receipt()
+    receipt["metadata"] = {
+        "command": "do-not-run",
+    }
+
+    with pytest.raises(ReceiptSealError):
+        seal_receipt(
+            receipt,
+            previous_cid=None,
+            ipfs=ipfs,
+            ledger=ledger,
+        )
+
+    assert ledger.read_events() == []
+
+
+def test_corrupt_ipfs_readback_fails_verification(tmp_path):
+    class CorruptIpfsWriter(InMemoryIpfsWriter):
+        def cat(self, cid):
+            return b"corrupt"
+
+    ipfs = CorruptIpfsWriter()
+    ledger = JsonlReceiptLedger(tmp_path / "receipt_ledger.jsonl")
+
+    with pytest.raises(ReceiptSealError):
+        seal_receipt(
+            trade_receipt(),
+            previous_cid=None,
+            ipfs=ipfs,
+            ledger=ledger,
+        )
+
+    assert ledger.read_events() == []
+
+
+def test_trade_cannot_settle_without_receipt_cid():
+    with pytest.raises(ReceiptSealError):
+        mark_action_complete(
+            "trade",
+            receipt_cid=None,
+            target_status="SETTLED",
+        )
+
+
+def test_charity_tx_cannot_complete_without_receipt_cid():
+    with pytest.raises(ReceiptSealError):
+        mark_action_complete(
+            "charity_tx",
+            receipt_cid=None,
+            target_status="COMPLETE",
+        )
+
+
+def test_action_can_complete_with_verified_receipt_cid(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger = JsonlReceiptLedger(tmp_path / "receipt_ledger.jsonl")
+
+    result = seal_receipt(
+        trade_receipt(),
+        previous_cid=None,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    completed = mark_action_complete(
+        "trade",
+        receipt_cid=result["cid"],
+        target_status="SETTLED",
+    )
+
+    assert completed["status"] == "SETTLED"
+    assert completed["receipt_cid"] == result["cid"]


### PR DESCRIPTION
Adds the first immutable receipt gate for trade and charity transaction artifacts.

Scope:
- adds deterministic canonical JSON receipt envelopes
- adds local SHA-256 receipt hashing
- adds in-memory IPFS writer for mock add/pin/cat verification
- adds append-only JSONL receipt ledger
- rejects forbidden secret, wallet, command, scheduler, webhook, and shell fields
- requires verified receipt CIDs before trade settlement or charity completion
- supports linked trade → charity receipt chains
- adds regression tests for receipt sealing, pin verification, ledger writes, forbidden fields, and completion gating

Safety boundary:
- mock IPFS adapter only
- no real wallet access
- no transaction signing
- no autonomous capital movement
- no scheduler
- no webhook execution
- no shell execution
- no private keys or secrets in receipts
- artifacts are records, not commands

Law:
No receipt CID, no completion.
No pin verification, no completion.
No receipt chain, no next action.
The artifact records.
The human promotes.
The chain remembers.
