### PR TITLE
Add local IPFS adapter boundary

### DIFF
--- a/eve_q/ipfs_adapters.py
+++ b/eve_q/ipfs_adapters.py
@@ -1,0 +1,128 @@
+import json
+import mimetypes
+import uuid
+from dataclasses import dataclass
+from typing import Protocol
+from urllib import parse, request
+
+DEFAULT_KUBO_API_URL = "http://127.0.0.1:5001"
+
+
+class IpfsWriter(Protocol):
+    def add_and_pin(self, data: bytes) -> str:
+        pass
+
+    def cat(self, cid: str) -> bytes:
+        pass
+
+    def is_pinned(self, cid: str) -> bool:
+        pass
+
+
+@dataclass(frozen=True)
+class KuboHttpIpfsWriter:
+    api_url: str = DEFAULT_KUBO_API_URL
+    timeout_seconds: int = 10
+
+    def endpoint(self, path: str) -> str:
+        return self.api_url.rstrip("/") + path
+
+    def add_and_pin(self, data: bytes) -> str:
+        boundary = "----eveqreceipt" + uuid.uuid4().hex
+        body = multipart_body(
+            boundary=boundary,
+            field_name="file",
+            filename="receipt.json",
+            data=data,
+            content_type="application/json",
+        )
+
+        url = self.endpoint("/api/v0/add?pin=true&cid-version=1")
+        headers = {
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+        }
+
+        response = post_bytes(
+            url,
+            body,
+            headers=headers,
+            timeout_seconds=self.timeout_seconds,
+        )
+
+        payload = json.loads(response.decode("utf-8"))
+        cid = payload.get("Hash")
+
+        if not cid:
+            raise RuntimeError("Kubo add response did not include Hash")
+
+        return str(cid)
+
+    def cat(self, cid: str) -> bytes:
+        query = parse.urlencode({"arg": cid})
+        url = self.endpoint(f"/api/v0/cat?{query}")
+
+        return post_bytes(
+            url,
+            b"",
+            headers={},
+            timeout_seconds=self.timeout_seconds,
+        )
+
+    def is_pinned(self, cid: str) -> bool:
+        query = parse.urlencode({"arg": cid, "type": "recursive"})
+        url = self.endpoint(f"/api/v0/pin/ls?{query}")
+
+        try:
+            response = post_bytes(
+                url,
+                b"",
+                headers={},
+                timeout_seconds=self.timeout_seconds,
+            )
+        except Exception:
+            return False
+
+        payload = json.loads(response.decode("utf-8"))
+        keys = payload.get("Keys", {})
+
+        return cid in keys
+
+
+def post_bytes(
+    url: str,
+    data: bytes,
+    headers: dict[str, str],
+    timeout_seconds: int,
+) -> bytes:
+    req = request.Request(
+        url,
+        data=data,
+        headers=headers,
+        method="POST",
+    )
+
+    with request.urlopen(req, timeout=timeout_seconds) as response:
+        return response.read()
+
+
+def multipart_body(
+    boundary: str,
+    field_name: str,
+    filename: str,
+    data: bytes,
+    content_type: str | None = None,
+) -> bytes:
+    guessed_type = mimetypes.guess_type(filename)[0]
+    final_type = content_type or guessed_type or "application/octet-stream"
+
+    lines = [
+        f"--{boundary}",
+        (f'Content-Disposition: form-data; name="{field_name}"; ' f'filename="{filename}"'),
+        f"Content-Type: {final_type}",
+        "",
+    ]
+
+    head = "\r\n".join(lines).encode("utf-8") + b"\r\n"
+    tail = f"\r\n--{boundary}--\r\n".encode("utf-8")
+
+    return head + data + tail

--- a/tests/test_ipfs_adapters.py
+++ b/tests/test_ipfs_adapters.py
@@ -1,0 +1,133 @@
+import json
+
+from eve_q.ipfs_adapters import (
+    KuboHttpIpfsWriter,
+    multipart_body,
+)
+
+
+def test_multipart_body_contains_receipt_bytes():
+    body = multipart_body(
+        boundary="BOUNDARY",
+        field_name="file",
+        filename="receipt.json",
+        data=b'{"ok":true}',
+        content_type="application/json",
+    )
+
+    assert b"--BOUNDARY" in body
+    assert b'name="file"' in body
+    assert b'filename="receipt.json"' in body
+    assert b"Content-Type: application/json" in body
+    assert b'{"ok":true}' in body
+    assert body.endswith(b"--BOUNDARY--\r\n")
+
+
+def test_kubo_endpoint_normalizes_url():
+    writer = KuboHttpIpfsWriter(api_url="http://127.0.0.1:5001/")
+
+    assert writer.endpoint("/api/v0/cat") == ("http://127.0.0.1:5001/api/v0/cat")
+
+
+def test_kubo_add_and_pin_uses_hash_response(monkeypatch):
+    calls = []
+
+    def fake_post_bytes(url, data, headers, timeout_seconds):
+        calls.append(
+            {
+                "url": url,
+                "data": data,
+                "headers": headers,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return json.dumps({"Hash": "bafy-test-cid"}).encode("utf-8")
+
+    monkeypatch.setattr(
+        "eve_q.ipfs_adapters.post_bytes",
+        fake_post_bytes,
+    )
+
+    writer = KuboHttpIpfsWriter(api_url="http://127.0.0.1:5001")
+    cid = writer.add_and_pin(b'{"receipt":true}')
+
+    assert cid == "bafy-test-cid"
+    assert calls[0]["url"] == ("http://127.0.0.1:5001/api/v0/add?pin=true&cid-version=1")
+    assert "multipart/form-data" in calls[0]["headers"]["Content-Type"]
+    assert b'{"receipt":true}' in calls[0]["data"]
+
+
+def test_kubo_cat_posts_to_local_api(monkeypatch):
+    calls = []
+
+    def fake_post_bytes(url, data, headers, timeout_seconds):
+        calls.append(
+            {
+                "url": url,
+                "data": data,
+                "headers": headers,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return b"receipt-bytes"
+
+    monkeypatch.setattr(
+        "eve_q.ipfs_adapters.post_bytes",
+        fake_post_bytes,
+    )
+
+    writer = KuboHttpIpfsWriter()
+    result = writer.cat("bafy-test-cid")
+
+    assert result == b"receipt-bytes"
+    assert calls[0]["url"] == ("http://127.0.0.1:5001/api/v0/cat?arg=bafy-test-cid")
+    assert calls[0]["data"] == b""
+
+
+def test_kubo_pin_check_returns_true_when_cid_present(monkeypatch):
+    def fake_post_bytes(url, data, headers, timeout_seconds):
+        payload = {
+            "Keys": {
+                "bafy-test-cid": {
+                    "Type": "recursive",
+                }
+            }
+        }
+        return json.dumps(payload).encode("utf-8")
+
+    monkeypatch.setattr(
+        "eve_q.ipfs_adapters.post_bytes",
+        fake_post_bytes,
+    )
+
+    writer = KuboHttpIpfsWriter()
+
+    assert writer.is_pinned("bafy-test-cid") is True
+
+
+def test_kubo_pin_check_returns_false_when_cid_missing(monkeypatch):
+    def fake_post_bytes(url, data, headers, timeout_seconds):
+        return json.dumps({"Keys": {}}).encode("utf-8")
+
+    monkeypatch.setattr(
+        "eve_q.ipfs_adapters.post_bytes",
+        fake_post_bytes,
+    )
+
+    writer = KuboHttpIpfsWriter()
+
+    assert writer.is_pinned("bafy-test-cid") is False
+
+
+def test_kubo_pin_check_returns_false_on_api_error(monkeypatch):
+    def fake_post_bytes(url, data, headers, timeout_seconds):
+        raise RuntimeError("local daemon unavailable")
+
+    monkeypatch.setattr(
+        "eve_q.ipfs_adapters.post_bytes",
+        fake_post_bytes,
+    )
+
+    writer = KuboHttpIpfsWriter()
+
+    assert writer.is_pinned("bafy-test-cid") is False


### PR DESCRIPTION
Adds the local IPFS adapter boundary for immutable receipt sealing.

Scope:
- adds an IPFS writer protocol
- adds local Kubo HTTP adapter targeting 127.0.0.1:5001
- supports add+pin through /api/v0/add
- supports readback through /api/v0/cat
- supports recursive pin checks through /api/v0/pin/ls
- uses only Python standard library networking
- tests adapter behavior with mocked HTTP calls
- does not require a live IPFS daemon in tests

Safety boundary:
- adapter boundary only
- no wallet access
- no transaction signing
- no autonomous capital movement
- no scheduler
- no webhook execution
- no shell execution
- no private keys or secrets
- receipts remain artifacts, not commands

Law:
No receipt CID, no completion.
No pin verification, no completion.
Local IPFS may remember.
The artifact records.
The human promotes.
The chain remembers.
