### PR TITLE
Add receipt sealer CLI

### DIFF
--- a/eve_q/receipt_sealer.py
+++ b/eve_q/receipt_sealer.py
@@ -1,0 +1,129 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from eve_q.immutable_receipts import (
+    InMemoryIpfsWriter,
+    JsonlReceiptLedger,
+    ReceiptSealError,
+    seal_receipt,
+)
+from eve_q.ipfs_adapters import (
+    DEFAULT_KUBO_API_URL,
+    KuboHttpIpfsWriter,
+)
+
+BACKEND_MOCK = "mock"
+BACKEND_KUBO = "kubo"
+BACKENDS = {BACKEND_MOCK, BACKEND_KUBO}
+
+
+def load_receipt(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def build_ipfs_writer(
+    backend: str,
+    kubo_api_url: str = DEFAULT_KUBO_API_URL,
+):
+    if backend == BACKEND_MOCK:
+        return InMemoryIpfsWriter()
+
+    if backend == BACKEND_KUBO:
+        return KuboHttpIpfsWriter(api_url=kubo_api_url)
+
+    raise ValueError(f"unknown receipt backend: {backend}")
+
+
+def seal_receipt_file(
+    receipt_path: Path,
+    ledger_path: Path,
+    backend: str = BACKEND_MOCK,
+    previous_cid: str | None = None,
+    kubo_api_url: str = DEFAULT_KUBO_API_URL,
+) -> dict[str, Any]:
+    receipt = load_receipt(receipt_path)
+    ipfs = build_ipfs_writer(backend, kubo_api_url)
+    ledger = JsonlReceiptLedger(ledger_path)
+
+    result = seal_receipt(
+        receipt=receipt,
+        previous_cid=previous_cid,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    return {
+        "backend": backend,
+        "receipt_path": str(receipt_path),
+        "ledger_path": str(ledger_path),
+        "result": result,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seal a trade or charity receipt artifact.")
+    parser.add_argument(
+        "--receipt",
+        required=True,
+        help="Path to receipt JSON file.",
+    )
+    parser.add_argument(
+        "--ledger",
+        required=True,
+        help="Path to append-only receipt ledger JSONL file.",
+    )
+    parser.add_argument(
+        "--backend",
+        default=BACKEND_MOCK,
+        choices=sorted(BACKENDS),
+        help="Receipt sealing backend.",
+    )
+    parser.add_argument(
+        "--previous-cid",
+        default=None,
+        help="Previous receipt CID for receipt chaining.",
+    )
+    parser.add_argument(
+        "--kubo-api-url",
+        default=DEFAULT_KUBO_API_URL,
+        help="Local Kubo API URL for kubo backend.",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        sealed = seal_receipt_file(
+            receipt_path=Path(args.receipt),
+            ledger_path=Path(args.ledger),
+            backend=args.backend,
+            previous_cid=args.previous_cid,
+            kubo_api_url=args.kubo_api_url,
+        )
+    except (ReceiptSealError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": str(exc),
+                },
+                sort_keys=True,
+            )
+        )
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                **sealed,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_receipt_sealer.py
+++ b/tests/test_receipt_sealer.py
@@ -1,0 +1,161 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from eve_q.immutable_receipts import (
+    InMemoryIpfsWriter,
+    JsonlReceiptLedger,
+)
+from eve_q.ipfs_adapters import KuboHttpIpfsWriter
+from eve_q.receipt_sealer import (
+    BACKEND_KUBO,
+    BACKEND_MOCK,
+    build_ipfs_writer,
+    seal_receipt_file,
+)
+
+
+def trade_receipt():
+    return {
+        "receipt_type": "TradeReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "strategy_id": "eve_q.shadow_v0",
+        "order_intent_hash": "sha256:intent",
+        "risk_report_hash": "sha256:risk",
+        "human_approval_hash": "sha256:approval",
+        "execution_result_hash": "sha256:execution",
+        "profit_loss": "0.00",
+        "charity_allocation_rule": "15_percent_positive_profit",
+    }
+
+
+def write_receipt(path: Path, receipt: dict):
+    path.write_text(json.dumps(receipt, sort_keys=True) + "\n")
+
+
+def test_build_ipfs_writer_selects_mock_backend():
+    writer = build_ipfs_writer(BACKEND_MOCK)
+
+    assert isinstance(writer, InMemoryIpfsWriter)
+
+
+def test_build_ipfs_writer_selects_kubo_backend():
+    writer = build_ipfs_writer(
+        BACKEND_KUBO,
+        kubo_api_url="http://127.0.0.1:5001",
+    )
+
+    assert isinstance(writer, KuboHttpIpfsWriter)
+    assert writer.api_url == "http://127.0.0.1:5001"
+
+
+def test_build_ipfs_writer_rejects_unknown_backend():
+    with pytest.raises(ValueError):
+        build_ipfs_writer("unknown")
+
+
+def test_seal_receipt_file_with_mock_backend_writes_ledger(tmp_path):
+    receipt_path = tmp_path / "trade_receipt.json"
+    ledger_path = tmp_path / "receipt_ledger.jsonl"
+    write_receipt(receipt_path, trade_receipt())
+
+    output = seal_receipt_file(
+        receipt_path=receipt_path,
+        ledger_path=ledger_path,
+        backend=BACKEND_MOCK,
+    )
+
+    assert output["backend"] == BACKEND_MOCK
+    assert output["result"]["status"] == "IPFS_PINNED_VERIFIED"
+    assert output["result"]["cid"].startswith("mock-ipfs-")
+
+    ledger = JsonlReceiptLedger(ledger_path)
+    events = ledger.read_events()
+
+    assert len(events) == 1
+    assert events[0]["receipt_type"] == "TradeReceipt"
+
+
+def test_seal_receipt_file_preserves_previous_cid(tmp_path):
+    receipt_path = tmp_path / "trade_receipt.json"
+    ledger_path = tmp_path / "receipt_ledger.jsonl"
+    previous_cid = "bafy-previous"
+    write_receipt(receipt_path, trade_receipt())
+
+    output = seal_receipt_file(
+        receipt_path=receipt_path,
+        ledger_path=ledger_path,
+        backend=BACKEND_MOCK,
+        previous_cid=previous_cid,
+    )
+
+    assert output["result"]["envelope"]["previous_cid"] == previous_cid
+    assert output["result"]["ledger_event"]["previous_cid"] == previous_cid
+
+
+def test_cli_seals_receipt_file_with_mock_backend(tmp_path):
+    receipt_path = tmp_path / "trade_receipt.json"
+    ledger_path = tmp_path / "receipt_ledger.jsonl"
+    write_receipt(receipt_path, trade_receipt())
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.receipt_sealer",
+            "--receipt",
+            str(receipt_path),
+            "--ledger",
+            str(ledger_path),
+            "--backend",
+            BACKEND_MOCK,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = json.loads(result.stdout)
+
+    assert output["ok"] is True
+    assert output["backend"] == BACKEND_MOCK
+    assert output["result"]["status"] == "IPFS_PINNED_VERIFIED"
+    assert ledger_path.exists()
+
+
+def test_cli_rejects_forbidden_secret_without_ledger_event(tmp_path):
+    receipt_path = tmp_path / "bad_receipt.json"
+    ledger_path = tmp_path / "receipt_ledger.jsonl"
+    receipt = trade_receipt()
+    receipt["wallet_private_key"] = "do-not-store"
+    write_receipt(receipt_path, receipt)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.receipt_sealer",
+            "--receipt",
+            str(receipt_path),
+            "--ledger",
+            str(ledger_path),
+            "--backend",
+            BACKEND_MOCK,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert output["ok"] is False
+    assert "forbidden receipt fields present" in output["error"]
+
+    if ledger_path.exists():
+        assert ledger_path.read_text() == ""


### PR DESCRIPTION
Adds selectable receipt sealing backend and CLI smoke path.

Scope:
- adds receipt sealer module
- supports mock backend for tests and dry runs
- supports local Kubo backend selection
- seals receipt JSON files into immutable receipt envelopes
- writes append-only JSONL receipt ledger events
- preserves previous CID chaining
- rejects forbidden receipt fields before ledger writes
- adds CLI coverage and regression tests

Safety boundary:
- receipt sealing only
- no wallet access
- no transaction signing
- no autonomous capital movement
- no scheduler
- no webhook execution
- no shell execution
- no private keys or secrets in receipts
- mock backend remains default
- Kubo backend is explicit opt-in

Law:
No receipt CID, no completion.
No pin verification, no completion.
No receipt chain, no next action.
The sealer binds the artifact.
The human promotes.
The chain remembers.
