### PR TITLE
Add receipt Merkle audit root

### DIFF
--- a/eve_q/receipt_merkle_audit.py
+++ b/eve_q/receipt_merkle_audit.py
@@ -1,0 +1,148 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from eve_q.immutable_receipts import (
+    JsonlReceiptLedger,
+    canonical_json_bytes,
+    sha256_hex,
+)
+from eve_q.receipt_ledger_audit import audit_receipt_ledger
+
+MERKLE_SCHEMA = "eve_q.receipt_merkle_audit.v0.1"
+MERKLE_VERSION = "0.1.0"
+
+
+def event_leaf_hash(event: dict[str, Any]) -> str:
+    return sha256_hex(canonical_json_bytes(event))
+
+
+def merkle_parent(left_hash: str, right_hash: str) -> str:
+    combined = bytes.fromhex(left_hash) + bytes.fromhex(right_hash)
+    return sha256_hex(combined)
+
+
+def merkle_root(leaf_hashes: list[str]) -> str | None:
+    if not leaf_hashes:
+        return None
+
+    level = list(leaf_hashes)
+
+    while len(level) > 1:
+        next_level = []
+
+        for index in range(0, len(level), 2):
+            left = level[index]
+            right = level[index + 1] if index + 1 < len(level) else left
+            next_level.append(merkle_parent(left, right))
+
+        level = next_level
+
+    return level[0]
+
+
+def build_receipt_merkle_audit(
+    ledger_path: Path,
+    period: str | None = None,
+) -> dict[str, Any]:
+    ledger = JsonlReceiptLedger(ledger_path)
+    events = ledger.read_events()
+    ledger_audit = audit_receipt_ledger(ledger_path)
+
+    leaves = [
+        {
+            "sequence": event.get("sequence"),
+            "cid": event.get("cid"),
+            "leaf_sha256": event_leaf_hash(event),
+        }
+        for event in events
+    ]
+
+    root = merkle_root([leaf["leaf_sha256"] for leaf in leaves])
+    errors = []
+
+    if not events:
+        errors.append(
+            {
+                "error": "empty_ledger",
+            }
+        )
+
+    if not ledger_audit["valid"]:
+        errors.append(
+            {
+                "error": "ledger_audit_invalid",
+            }
+        )
+
+    return {
+        "schema": MERKLE_SCHEMA,
+        "version": MERKLE_VERSION,
+        "period": period,
+        "ledger_path": str(ledger_path),
+        "event_count": len(events),
+        "ledger_valid": ledger_audit["valid"],
+        "valid": not errors,
+        "errors": errors,
+        "merkle_root": root,
+        "latest_cid": ledger_audit["latest_cid"],
+        "leaves": leaves,
+        "ledger_audit": ledger_audit,
+        "execution_authority": "none",
+        "artifact_is_command": False,
+        "may_execute": False,
+        "may_move_capital": False,
+        "boundary_law": [
+            "No receipt CID, no completion.",
+            "No pin verification, no completion.",
+            "No receipt chain, no next action.",
+            "The Merkle root compresses continuity.",
+            "The artifact records.",
+            "The human promotes.",
+            "The chain remembers.",
+        ],
+    }
+
+
+def write_merkle_audit(packet: dict[str, Any], output_path: Path) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n")
+
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a Merkle audit root for a receipt ledger.")
+    parser.add_argument(
+        "--ledger",
+        required=True,
+        help="Path to append-only receipt ledger JSONL file.",
+    )
+    parser.add_argument(
+        "--period",
+        default=None,
+        help="Optional period label, such as 2026-07-08.",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional JSON output path for the Merkle audit packet.",
+    )
+
+    args = parser.parse_args()
+
+    packet = build_receipt_merkle_audit(
+        Path(args.ledger),
+        period=args.period,
+    )
+
+    if args.output:
+        write_merkle_audit(packet, Path(args.output))
+
+    print(json.dumps(packet, sort_keys=True))
+    return 0 if packet["valid"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_receipt_merkle_audit.py
+++ b/tests/test_receipt_merkle_audit.py
@@ -1,0 +1,196 @@
+import json
+import subprocess
+import sys
+
+from eve_q.immutable_receipts import (
+    InMemoryIpfsWriter,
+    JsonlReceiptLedger,
+    seal_receipt,
+)
+from eve_q.receipt_merkle_audit import (
+    build_receipt_merkle_audit,
+    event_leaf_hash,
+    merkle_parent,
+    merkle_root,
+)
+
+
+def trade_receipt():
+    return {
+        "receipt_type": "TradeReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "strategy_id": "eve_q.shadow_v0",
+        "order_intent_hash": "sha256:intent",
+        "risk_report_hash": "sha256:risk",
+        "human_approval_hash": "sha256:approval",
+        "execution_result_hash": "sha256:execution",
+        "profit_loss": "0.00",
+        "charity_allocation_rule": "15_percent_positive_profit",
+    }
+
+
+def charity_receipt(source_trade_cid):
+    return {
+        "receipt_type": "CharityTxReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "source_trade_receipt_cid": source_trade_cid,
+        "charity_policy_id": "charity_geodesic_v0",
+        "recipient_id_hash": "sha256:recipient",
+        "amount": "0.00",
+        "currency": "USD",
+        "tx_ref_hash": "sha256:txref",
+        "verification_status": "simulated",
+    }
+
+
+def build_two_event_ledger(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger_path = tmp_path / "receipt_ledger.jsonl"
+    ledger = JsonlReceiptLedger(ledger_path)
+
+    trade = seal_receipt(
+        trade_receipt(),
+        previous_cid=None,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+    charity = seal_receipt(
+        charity_receipt(trade["cid"]),
+        previous_cid=trade["cid"],
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    return ledger_path, trade, charity
+
+
+def write_events(path, events):
+    path.write_text("\n".join(json.dumps(event, sort_keys=True) for event in events) + "\n")
+
+
+def test_event_leaf_hash_is_deterministic():
+    first = event_leaf_hash({"b": 2, "a": 1})
+    second = event_leaf_hash({"a": 1, "b": 2})
+
+    assert first == second
+
+
+def test_merkle_root_empty_is_none():
+    assert merkle_root([]) is None
+
+
+def test_merkle_root_single_leaf_is_leaf():
+    leaf = event_leaf_hash({"sequence": 1})
+
+    assert merkle_root([leaf]) == leaf
+
+
+def test_merkle_parent_is_deterministic():
+    left = event_leaf_hash({"sequence": 1})
+    right = event_leaf_hash({"sequence": 2})
+
+    assert merkle_parent(left, right) == merkle_parent(left, right)
+    assert merkle_parent(left, right) != merkle_parent(right, left)
+
+
+def test_merkle_audit_accepts_valid_ledger(tmp_path):
+    ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+
+    packet = build_receipt_merkle_audit(
+        ledger_path,
+        period="2026-07-08",
+    )
+
+    assert packet["valid"] is True
+    assert packet["ledger_valid"] is True
+    assert packet["event_count"] == 2
+    assert packet["period"] == "2026-07-08"
+    assert packet["latest_cid"] == charity["cid"]
+    assert packet["merkle_root"]
+    assert len(packet["leaves"]) == 2
+    assert packet["execution_authority"] == "none"
+    assert packet["artifact_is_command"] is False
+    assert packet["may_execute"] is False
+    assert packet["may_move_capital"] is False
+
+
+def test_merkle_audit_rejects_empty_ledger(tmp_path):
+    ledger_path = tmp_path / "empty.jsonl"
+
+    packet = build_receipt_merkle_audit(ledger_path)
+
+    assert packet["valid"] is False
+    assert packet["event_count"] == 0
+    assert packet["merkle_root"] is None
+    assert any(error["error"] == "empty_ledger" for error in packet["errors"])
+
+
+def test_merkle_audit_detects_invalid_ledger(tmp_path):
+    ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+    events = JsonlReceiptLedger(ledger_path).read_events()
+    events[1]["previous_cid"] = "wrong-cid"
+    write_events(ledger_path, events)
+
+    packet = build_receipt_merkle_audit(ledger_path)
+
+    assert packet["valid"] is False
+    assert packet["ledger_valid"] is False
+    assert any(error["error"] == "ledger_audit_invalid" for error in packet["errors"])
+
+
+def test_cli_writes_merkle_audit_packet(tmp_path):
+    ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+    output_path = tmp_path / "daily_merkle_audit.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.receipt_merkle_audit",
+            "--ledger",
+            str(ledger_path),
+            "--period",
+            "2026-07-08",
+            "--output",
+            str(output_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    packet = json.loads(result.stdout)
+    written = json.loads(output_path.read_text())
+
+    assert packet["valid"] is True
+    assert written == packet
+    assert written["merkle_root"]
+    assert written["latest_cid"] == charity["cid"]
+
+
+def test_cli_returns_one_for_invalid_ledger(tmp_path):
+    ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+    events = JsonlReceiptLedger(ledger_path).read_events()
+    events[0]["may_execute"] = True
+    write_events(ledger_path, events)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.receipt_merkle_audit",
+            "--ledger",
+            str(ledger_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    packet = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert packet["valid"] is False
+    assert packet["ledger_valid"] is False


### PR DESCRIPTION
Adds daily Merkle audit root packet for immutable receipt ledgers.

Scope:
- builds deterministic event leaf hashes from receipt ledger events
- computes Merkle roots over receipt ledger leaves
- embeds receipt ledger audit results
- preserves latest CID continuity
- supports optional period labels such as daily UTC dates
- supports optional JSON packet output
- returns non-zero status for empty or invalid ledgers
- adds CLI coverage and regression tests

Safety boundary:
- audit/root generation only
- no wallet access
- no transaction signing
- no autonomous capital movement
- no scheduler
- no webhook execution
- no shell execution
- no private keys or secrets
- no IPFS daemon required
- artifacts remain records, not commands

Law:
No receipt CID, no completion.
No pin verification, no completion.
No receipt chain, no next action.
The Merkle root compresses continuity.
The artifact records.
The human promotes.
The chain remembers.
