### PR TITLE
Add receipt Merkle anchor

### DIFF
--- a/eve_q/receipt_merkle_anchor.py
+++ b/eve_q/receipt_merkle_anchor.py
@@ -1,0 +1,162 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from eve_q.immutable_receipts import (
+    JsonlReceiptLedger,
+    ReceiptSealError,
+    canonical_json_bytes,
+    seal_receipt,
+    sha256_hex,
+)
+from eve_q.ipfs_adapters import DEFAULT_KUBO_API_URL
+from eve_q.receipt_merkle_audit import build_receipt_merkle_audit
+from eve_q.receipt_sealer import (
+    BACKEND_MOCK,
+    BACKENDS,
+    build_ipfs_writer,
+)
+
+ANCHOR_RECEIPT_TYPE = "ReceiptMerkleAnchorReceipt"
+ANCHOR_RECEIPT_VERSION = "0.1.0"
+
+
+def merkle_packet_digest(packet: dict[str, Any]) -> str:
+    return sha256_hex(canonical_json_bytes(packet))
+
+
+def build_merkle_anchor_receipt(
+    merkle_packet: dict[str, Any],
+) -> dict[str, Any]:
+    if not merkle_packet.get("valid"):
+        raise ReceiptSealError("cannot anchor invalid Merkle audit packet")
+
+    merkle_root = merkle_packet.get("merkle_root")
+
+    if not merkle_root:
+        raise ReceiptSealError("cannot anchor Merkle audit packet without root")
+
+    return {
+        "receipt_type": ANCHOR_RECEIPT_TYPE,
+        "receipt_version": ANCHOR_RECEIPT_VERSION,
+        "period": merkle_packet.get("period"),
+        "source_ledger_path": merkle_packet.get("ledger_path"),
+        "event_count": merkle_packet.get("event_count"),
+        "ledger_valid": merkle_packet.get("ledger_valid"),
+        "latest_cid": merkle_packet.get("latest_cid"),
+        "merkle_root": merkle_root,
+        "merkle_packet_schema": merkle_packet.get("schema"),
+        "merkle_packet_sha256": merkle_packet_digest(merkle_packet),
+        "anchor_scope": "audit_root_only",
+        "execution_authority": "none",
+        "artifact_is_command": False,
+        "may_execute": False,
+        "may_move_capital": False,
+    }
+
+
+def seal_merkle_anchor(
+    source_ledger_path: Path,
+    anchor_ledger_path: Path,
+    backend: str = BACKEND_MOCK,
+    period: str | None = None,
+    previous_anchor_cid: str | None = None,
+    kubo_api_url: str = DEFAULT_KUBO_API_URL,
+) -> dict[str, Any]:
+    merkle_packet = build_receipt_merkle_audit(
+        source_ledger_path,
+        period=period,
+    )
+    anchor_receipt = build_merkle_anchor_receipt(merkle_packet)
+    ipfs = build_ipfs_writer(backend, kubo_api_url)
+    anchor_ledger = JsonlReceiptLedger(anchor_ledger_path)
+
+    seal_result = seal_receipt(
+        receipt=anchor_receipt,
+        previous_cid=previous_anchor_cid,
+        ipfs=ipfs,
+        ledger=anchor_ledger,
+    )
+
+    return {
+        "backend": backend,
+        "source_ledger_path": str(source_ledger_path),
+        "anchor_ledger_path": str(anchor_ledger_path),
+        "merkle_packet": merkle_packet,
+        "anchor_receipt": anchor_receipt,
+        "result": seal_result,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seal a Merkle audit root as an anchor receipt.")
+    parser.add_argument(
+        "--ledger",
+        required=True,
+        help="Source receipt ledger JSONL file.",
+    )
+    parser.add_argument(
+        "--anchor-ledger",
+        required=True,
+        help="Separate append-only anchor ledger JSONL file.",
+    )
+    parser.add_argument(
+        "--backend",
+        default=BACKEND_MOCK,
+        choices=sorted(BACKENDS),
+        help="Receipt sealing backend.",
+    )
+    parser.add_argument(
+        "--period",
+        default=None,
+        help="Optional period label, such as 2026-07-08.",
+    )
+    parser.add_argument(
+        "--previous-anchor-cid",
+        default=None,
+        help="Previous Merkle anchor CID for anchor chaining.",
+    )
+    parser.add_argument(
+        "--kubo-api-url",
+        default=DEFAULT_KUBO_API_URL,
+        help="Local Kubo API URL for kubo backend.",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        anchored = seal_merkle_anchor(
+            source_ledger_path=Path(args.ledger),
+            anchor_ledger_path=Path(args.anchor_ledger),
+            backend=args.backend,
+            period=args.period,
+            previous_anchor_cid=args.previous_anchor_cid,
+            kubo_api_url=args.kubo_api_url,
+        )
+    except (ReceiptSealError, ValueError) as exc:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": str(exc),
+                },
+                sort_keys=True,
+            )
+        )
+        return 1
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                **anchored,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_receipt_merkle_anchor.py
+++ b/tests/test_receipt_merkle_anchor.py
@@ -1,0 +1,205 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+from eve_q.immutable_receipts import (
+    InMemoryIpfsWriter,
+    JsonlReceiptLedger,
+    ReceiptSealError,
+    seal_receipt,
+)
+from eve_q.receipt_merkle_anchor import (
+    ANCHOR_RECEIPT_TYPE,
+    build_merkle_anchor_receipt,
+    merkle_packet_digest,
+    seal_merkle_anchor,
+)
+from eve_q.receipt_merkle_audit import build_receipt_merkle_audit
+from eve_q.receipt_sealer import BACKEND_MOCK
+
+
+def trade_receipt():
+    return {
+        "receipt_type": "TradeReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "strategy_id": "eve_q.shadow_v0",
+        "order_intent_hash": "sha256:intent",
+        "risk_report_hash": "sha256:risk",
+        "human_approval_hash": "sha256:approval",
+        "execution_result_hash": "sha256:execution",
+        "profit_loss": "0.00",
+        "charity_allocation_rule": "15_percent_positive_profit",
+    }
+
+
+def charity_receipt(source_trade_cid):
+    return {
+        "receipt_type": "CharityTxReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "source_trade_receipt_cid": source_trade_cid,
+        "charity_policy_id": "charity_geodesic_v0",
+        "recipient_id_hash": "sha256:recipient",
+        "amount": "0.00",
+        "currency": "USD",
+        "tx_ref_hash": "sha256:txref",
+        "verification_status": "simulated",
+    }
+
+
+def build_two_event_ledger(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger_path = tmp_path / "receipt_ledger.jsonl"
+    ledger = JsonlReceiptLedger(ledger_path)
+
+    trade = seal_receipt(
+        trade_receipt(),
+        previous_cid=None,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+    charity = seal_receipt(
+        charity_receipt(trade["cid"]),
+        previous_cid=trade["cid"],
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    return ledger_path, trade, charity
+
+
+def test_merkle_packet_digest_is_deterministic():
+    first = merkle_packet_digest({"b": 2, "a": 1})
+    second = merkle_packet_digest({"a": 1, "b": 2})
+
+    assert first == second
+
+
+def test_build_anchor_receipt_from_valid_merkle_packet(tmp_path):
+    ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+    packet = build_receipt_merkle_audit(
+        ledger_path,
+        period="2026-07-08",
+    )
+
+    receipt = build_merkle_anchor_receipt(packet)
+
+    assert receipt["receipt_type"] == ANCHOR_RECEIPT_TYPE
+    assert receipt["period"] == "2026-07-08"
+    assert receipt["event_count"] == 2
+    assert receipt["latest_cid"] == charity["cid"]
+    assert receipt["merkle_root"] == packet["merkle_root"]
+    assert receipt["merkle_packet_sha256"] == merkle_packet_digest(packet)
+    assert receipt["execution_authority"] == "none"
+    assert receipt["artifact_is_command"] is False
+    assert receipt["may_execute"] is False
+    assert receipt["may_move_capital"] is False
+
+
+def test_build_anchor_receipt_rejects_invalid_merkle_packet(tmp_path):
+    ledger_path = tmp_path / "empty.jsonl"
+    packet = build_receipt_merkle_audit(ledger_path)
+
+    with pytest.raises(ReceiptSealError):
+        build_merkle_anchor_receipt(packet)
+
+
+def test_seal_merkle_anchor_uses_separate_anchor_ledger(tmp_path):
+    source_ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+    anchor_ledger_path = tmp_path / "anchor_ledger.jsonl"
+
+    output = seal_merkle_anchor(
+        source_ledger_path=source_ledger_path,
+        anchor_ledger_path=anchor_ledger_path,
+        backend=BACKEND_MOCK,
+        period="2026-07-08",
+    )
+
+    source_events = JsonlReceiptLedger(source_ledger_path).read_events()
+    anchor_events = JsonlReceiptLedger(anchor_ledger_path).read_events()
+
+    assert len(source_events) == 2
+    assert len(anchor_events) == 1
+    assert output["result"]["status"] == "IPFS_PINNED_VERIFIED"
+    assert output["anchor_receipt"]["merkle_root"]
+    assert anchor_events[0]["receipt_type"] == ANCHOR_RECEIPT_TYPE
+
+
+def test_seal_merkle_anchor_preserves_previous_anchor_cid(tmp_path):
+    source_ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+    anchor_ledger_path = tmp_path / "anchor_ledger.jsonl"
+
+    output = seal_merkle_anchor(
+        source_ledger_path=source_ledger_path,
+        anchor_ledger_path=anchor_ledger_path,
+        backend=BACKEND_MOCK,
+        period="2026-07-08",
+        previous_anchor_cid="bafy-anchor-previous",
+    )
+
+    assert output["result"]["envelope"]["previous_cid"] == ("bafy-anchor-previous")
+    assert output["result"]["ledger_event"]["previous_cid"] == ("bafy-anchor-previous")
+
+
+def test_cli_seals_merkle_anchor_receipt(tmp_path):
+    source_ledger_path, trade, charity = build_two_event_ledger(tmp_path)
+    anchor_ledger_path = tmp_path / "anchor_ledger.jsonl"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.receipt_merkle_anchor",
+            "--ledger",
+            str(source_ledger_path),
+            "--anchor-ledger",
+            str(anchor_ledger_path),
+            "--backend",
+            BACKEND_MOCK,
+            "--period",
+            "2026-07-08",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = json.loads(result.stdout)
+    anchor_events = JsonlReceiptLedger(anchor_ledger_path).read_events()
+
+    assert output["ok"] is True
+    assert output["result"]["status"] == "IPFS_PINNED_VERIFIED"
+    assert output["anchor_receipt"]["receipt_type"] == ANCHOR_RECEIPT_TYPE
+    assert len(anchor_events) == 1
+
+
+def test_cli_rejects_empty_source_ledger_without_anchor_event(tmp_path):
+    source_ledger_path = tmp_path / "empty.jsonl"
+    anchor_ledger_path = tmp_path / "anchor_ledger.jsonl"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.receipt_merkle_anchor",
+            "--ledger",
+            str(source_ledger_path),
+            "--anchor-ledger",
+            str(anchor_ledger_path),
+            "--backend",
+            BACKEND_MOCK,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert output["ok"] is False
+    assert "cannot anchor invalid Merkle audit packet" in output["error"]
+    assert not anchor_ledger_path.exists()


### PR DESCRIPTION
Adds Merkle anchor receipt sealing for immutable receipt ledgers.

Scope:
- builds ReceiptMerkleAnchorReceipt payloads from valid Merkle audit packets
- seals Merkle roots through the existing receipt sealer path
- writes anchor events to a separate anchor ledger
- preserves source receipt ledger immutability after root computation
- supports previous anchor CID chaining
- supports mock and explicit Kubo backends
- rejects invalid or empty Merkle audit packets
- adds CLI coverage and regression tests

Safety boundary:
- anchor receipt sealing only
- source receipt ledger is not mutated
- anchor ledger is separate from source ledger
- no wallet access
- no transaction signing
- no autonomous capital movement
- no scheduler
- no webhook execution
- no shell execution
- no private keys or secrets
- artifacts remain records, not commands

Law:
The source ledger is remembered.
The anchor ledger witnesses.
The Merkle root compresses continuity.
No receipt CID, no completion.
No pin verification, no completion.
The human promotes.
The chain remembers.
