### PR TITLE
Add capital completion gate

### DIFF
--- a/eve_q/capital_action_gate.py
+++ b/eve_q/capital_action_gate.py
@@ -1,0 +1,203 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+GATE_SCHEMA = "eve_q.capital_action_completion_gate.v0.1"
+GATE_VERSION = "0.1.0"
+
+ACTION_TRADE = "trade"
+ACTION_CHARITY_TX = "charity_tx"
+
+CAPITAL_ACTION_KINDS = {
+    ACTION_TRADE,
+    ACTION_CHARITY_TX,
+}
+
+COMPLETE_STATUSES = {
+    "SETTLED",
+    "COMPLETE",
+}
+
+
+class CapitalActionGateError(RuntimeError):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text())
+
+
+def validate_ledger_audit(
+    ledger_audit: dict[str, Any],
+    receipt_cid: str,
+) -> None:
+    if ledger_audit.get("valid") is not True:
+        raise CapitalActionGateError("cannot complete capital action with invalid ledger audit")
+
+    if ledger_audit.get("latest_cid") != receipt_cid:
+        raise CapitalActionGateError("receipt CID must match audited latest CID")
+
+    if ledger_audit.get("execution_authority") != "none":
+        raise CapitalActionGateError("ledger audit execution authority must be none")
+
+    if ledger_audit.get("artifact_is_command") is not False:
+        raise CapitalActionGateError("ledger audit artifact_is_command must be false")
+
+    if ledger_audit.get("may_execute") is not False:
+        raise CapitalActionGateError("ledger audit may_execute must be false")
+
+    if ledger_audit.get("may_move_capital") is not False:
+        raise CapitalActionGateError("ledger audit may_move_capital must be false")
+
+
+def build_completion_certificate(
+    action_kind: str,
+    target_status: str,
+    receipt_cid: str | None,
+    ledger_audit: dict[str, Any],
+    source_receipt_cid: str | None = None,
+    merkle_anchor_cid: str | None = None,
+    require_merkle_anchor: bool = False,
+) -> dict[str, Any]:
+    if action_kind not in CAPITAL_ACTION_KINDS:
+        raise CapitalActionGateError(f"unsupported capital action kind: {action_kind}")
+
+    if target_status not in COMPLETE_STATUSES:
+        raise CapitalActionGateError(f"unsupported completion status: {target_status}")
+
+    if not receipt_cid:
+        raise CapitalActionGateError("capital action cannot complete without receipt CID")
+
+    if action_kind == ACTION_CHARITY_TX and not source_receipt_cid:
+        raise CapitalActionGateError("charity transaction requires source trade receipt CID")
+
+    if require_merkle_anchor and not merkle_anchor_cid:
+        raise CapitalActionGateError("Merkle anchor CID is required before completion")
+
+    validate_ledger_audit(ledger_audit, receipt_cid)
+
+    return {
+        "schema": GATE_SCHEMA,
+        "version": GATE_VERSION,
+        "action_kind": action_kind,
+        "target_status": target_status,
+        "completion_status": "ACCOUNTED",
+        "receipt_cid": receipt_cid,
+        "source_receipt_cid": source_receipt_cid,
+        "ledger_path": ledger_audit.get("ledger_path"),
+        "ledger_event_count": ledger_audit.get("event_count"),
+        "ledger_latest_cid": ledger_audit.get("latest_cid"),
+        "merkle_anchor_required": require_merkle_anchor,
+        "merkle_anchor_cid": merkle_anchor_cid,
+        "execution_authority": "none",
+        "artifact_is_command": False,
+        "may_execute": False,
+        "may_move_capital": False,
+        "human_promotion_required": True,
+        "boundary_law": [
+            "No receipt CID, no completion.",
+            "No valid ledger audit, no completion.",
+            "No charity completion without source trade receipt.",
+            "No required Merkle anchor, no completion.",
+            "The completion gate accounts.",
+            "The artifact records.",
+            "The human promotes.",
+            "The chain remembers.",
+        ],
+    }
+
+
+def write_completion_certificate(
+    certificate: dict[str, Any],
+    output_path: Path,
+) -> Path:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(certificate, indent=2, sort_keys=True) + "\n")
+
+    return output_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Gate trade or charity completion by receipt audit."
+    )
+    parser.add_argument(
+        "--action-kind",
+        required=True,
+        choices=sorted(CAPITAL_ACTION_KINDS),
+    )
+    parser.add_argument(
+        "--target-status",
+        required=True,
+        choices=sorted(COMPLETE_STATUSES),
+    )
+    parser.add_argument(
+        "--receipt-cid",
+        required=True,
+    )
+    parser.add_argument(
+        "--ledger-audit",
+        required=True,
+        help="Path to receipt ledger audit JSON packet.",
+    )
+    parser.add_argument(
+        "--source-receipt-cid",
+        default=None,
+        help="Required for charity_tx completion.",
+    )
+    parser.add_argument(
+        "--merkle-anchor-cid",
+        default=None,
+    )
+    parser.add_argument(
+        "--require-merkle-anchor",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Optional JSON output path.",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        certificate = build_completion_certificate(
+            action_kind=args.action_kind,
+            target_status=args.target_status,
+            receipt_cid=args.receipt_cid,
+            ledger_audit=load_json(Path(args.ledger_audit)),
+            source_receipt_cid=args.source_receipt_cid,
+            merkle_anchor_cid=args.merkle_anchor_cid,
+            require_merkle_anchor=args.require_merkle_anchor,
+        )
+    except CapitalActionGateError as exc:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": str(exc),
+                },
+                sort_keys=True,
+            )
+        )
+        return 1
+
+    if args.output:
+        write_completion_certificate(certificate, Path(args.output))
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "certificate": certificate,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capital_action_gate.py
+++ b/tests/test_capital_action_gate.py
@@ -1,0 +1,293 @@
+import json
+import subprocess
+import sys
+
+import pytest
+
+from eve_q.capital_action_gate import (
+    ACTION_CHARITY_TX,
+    ACTION_TRADE,
+    CapitalActionGateError,
+    build_completion_certificate,
+)
+from eve_q.immutable_receipts import (
+    InMemoryIpfsWriter,
+    JsonlReceiptLedger,
+    seal_receipt,
+)
+from eve_q.receipt_ledger_audit import audit_receipt_ledger
+
+
+def trade_receipt():
+    return {
+        "receipt_type": "TradeReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "strategy_id": "eve_q.shadow_v0",
+        "order_intent_hash": "sha256:intent",
+        "risk_report_hash": "sha256:risk",
+        "human_approval_hash": "sha256:approval",
+        "execution_result_hash": "sha256:execution",
+        "profit_loss": "0.00",
+        "charity_allocation_rule": "15_percent_positive_profit",
+    }
+
+
+def charity_receipt(source_trade_cid):
+    return {
+        "receipt_type": "CharityTxReceipt",
+        "receipt_version": "0.1.0",
+        "environment": "paper",
+        "source_trade_receipt_cid": source_trade_cid,
+        "charity_policy_id": "charity_geodesic_v0",
+        "recipient_id_hash": "sha256:recipient",
+        "amount": "0.00",
+        "currency": "USD",
+        "tx_ref_hash": "sha256:txref",
+        "verification_status": "simulated",
+    }
+
+
+def build_trade_ledger(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger_path = tmp_path / "trade_ledger.jsonl"
+    ledger = JsonlReceiptLedger(ledger_path)
+
+    trade = seal_receipt(
+        trade_receipt(),
+        previous_cid=None,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    return ledger_path, trade
+
+
+def build_trade_charity_ledger(tmp_path):
+    ipfs = InMemoryIpfsWriter()
+    ledger_path = tmp_path / "receipt_ledger.jsonl"
+    ledger = JsonlReceiptLedger(ledger_path)
+
+    trade = seal_receipt(
+        trade_receipt(),
+        previous_cid=None,
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+    charity = seal_receipt(
+        charity_receipt(trade["cid"]),
+        previous_cid=trade["cid"],
+        ipfs=ipfs,
+        ledger=ledger,
+    )
+
+    return ledger_path, trade, charity
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, sort_keys=True) + "\n")
+
+
+def test_trade_completion_certificate_accepts_valid_audit(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    certificate = build_completion_certificate(
+        action_kind=ACTION_TRADE,
+        target_status="SETTLED",
+        receipt_cid=trade["cid"],
+        ledger_audit=audit,
+    )
+
+    assert certificate["completion_status"] == "ACCOUNTED"
+    assert certificate["receipt_cid"] == trade["cid"]
+    assert certificate["ledger_latest_cid"] == trade["cid"]
+    assert certificate["execution_authority"] == "none"
+    assert certificate["artifact_is_command"] is False
+    assert certificate["may_execute"] is False
+    assert certificate["may_move_capital"] is False
+
+
+def test_charity_completion_requires_source_receipt_cid(tmp_path):
+    ledger_path, trade, charity = build_trade_charity_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    with pytest.raises(CapitalActionGateError):
+        build_completion_certificate(
+            action_kind=ACTION_CHARITY_TX,
+            target_status="COMPLETE",
+            receipt_cid=charity["cid"],
+            ledger_audit=audit,
+        )
+
+
+def test_charity_completion_accepts_source_receipt_cid(tmp_path):
+    ledger_path, trade, charity = build_trade_charity_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    certificate = build_completion_certificate(
+        action_kind=ACTION_CHARITY_TX,
+        target_status="COMPLETE",
+        receipt_cid=charity["cid"],
+        ledger_audit=audit,
+        source_receipt_cid=trade["cid"],
+    )
+
+    assert certificate["completion_status"] == "ACCOUNTED"
+    assert certificate["receipt_cid"] == charity["cid"]
+    assert certificate["source_receipt_cid"] == trade["cid"]
+
+
+def test_rejects_missing_receipt_cid(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    with pytest.raises(CapitalActionGateError):
+        build_completion_certificate(
+            action_kind=ACTION_TRADE,
+            target_status="SETTLED",
+            receipt_cid=None,
+            ledger_audit=audit,
+        )
+
+
+def test_rejects_invalid_ledger_audit(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+    audit["valid"] = False
+
+    with pytest.raises(CapitalActionGateError):
+        build_completion_certificate(
+            action_kind=ACTION_TRADE,
+            target_status="SETTLED",
+            receipt_cid=trade["cid"],
+            ledger_audit=audit,
+        )
+
+
+def test_rejects_latest_cid_mismatch(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    with pytest.raises(CapitalActionGateError):
+        build_completion_certificate(
+            action_kind=ACTION_TRADE,
+            target_status="SETTLED",
+            receipt_cid="wrong-cid",
+            ledger_audit=audit,
+        )
+
+
+def test_requires_merkle_anchor_when_policy_requires_it(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    with pytest.raises(CapitalActionGateError):
+        build_completion_certificate(
+            action_kind=ACTION_TRADE,
+            target_status="SETTLED",
+            receipt_cid=trade["cid"],
+            ledger_audit=audit,
+            require_merkle_anchor=True,
+        )
+
+
+def test_accepts_merkle_anchor_when_required(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    certificate = build_completion_certificate(
+        action_kind=ACTION_TRADE,
+        target_status="SETTLED",
+        receipt_cid=trade["cid"],
+        ledger_audit=audit,
+        merkle_anchor_cid="bafy-anchor",
+        require_merkle_anchor=True,
+    )
+
+    assert certificate["merkle_anchor_required"] is True
+    assert certificate["merkle_anchor_cid"] == "bafy-anchor"
+
+
+def test_rejects_authority_drift_in_audit_packet(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+    audit["may_move_capital"] = True
+
+    with pytest.raises(CapitalActionGateError):
+        build_completion_certificate(
+            action_kind=ACTION_TRADE,
+            target_status="SETTLED",
+            receipt_cid=trade["cid"],
+            ledger_audit=audit,
+        )
+
+
+def test_cli_writes_completion_certificate(tmp_path):
+    ledger_path, trade = build_trade_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+    audit_path = tmp_path / "ledger_audit.json"
+    output_path = tmp_path / "completion_certificate.json"
+
+    write_json(audit_path, audit)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.capital_action_gate",
+            "--action-kind",
+            ACTION_TRADE,
+            "--target-status",
+            "SETTLED",
+            "--receipt-cid",
+            trade["cid"],
+            "--ledger-audit",
+            str(audit_path),
+            "--output",
+            str(output_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    output = json.loads(result.stdout)
+    written = json.loads(output_path.read_text())
+
+    assert output["ok"] is True
+    assert written == output["certificate"]
+    assert written["completion_status"] == "ACCOUNTED"
+    assert written["receipt_cid"] == trade["cid"]
+
+
+def test_cli_rejects_charity_without_source_receipt(tmp_path):
+    ledger_path, trade, charity = build_trade_charity_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+    audit_path = tmp_path / "ledger_audit.json"
+    write_json(audit_path, audit)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "eve_q.capital_action_gate",
+            "--action-kind",
+            ACTION_CHARITY_TX,
+            "--target-status",
+            "COMPLETE",
+            "--receipt-cid",
+            charity["cid"],
+            "--ledger-audit",
+            str(audit_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    output = json.loads(result.stdout)
+
+    assert result.returncode == 1
+    assert output["ok"] is False
+    assert "source trade receipt CID" in output["error"]


### PR DESCRIPTION
Adds capital action completion gate for trade and charity accountability.

Scope:
- gates trade settlement on verified receipt CID and valid ledger audit
- gates charity transaction completion on verified receipt CID, valid ledger audit, and source trade receipt CID
- optionally requires Merkle anchor CID before completion
- emits non-executing completion certificates
- rejects invalid ledger audits
- rejects latest CID mismatches
- rejects authority drift in audit packets
- adds CLI coverage and regression tests

Safety boundary:
- accounting/completion gate only
- does not execute trades
- does not send charity transactions
- no wallet access
- no transaction signing
- no autonomous capital movement
- no scheduler
- no webhook execution
- no shell execution
- no private keys or secrets
- artifacts remain records, not commands

Law:
No receipt CID, no completion.
No valid ledger audit, no completion.
No charity completion without source trade receipt.
No required Merkle anchor, no completion.
The completion gate accounts.
The artifact records.
The human promotes.
The chain remembers.
