### PR TITLE
Allow completion from audited ledger membership

### DIFF
--- a/eve_q/capital_action_gate.py
+++ b/eve_q/capital_action_gate.py
@@ -35,8 +35,13 @@ def validate_ledger_audit(
     if ledger_audit.get("valid") is not True:
         raise CapitalActionGateError("cannot complete capital action with invalid ledger audit")
 
-    if ledger_audit.get("latest_cid") != receipt_cid:
-        raise CapitalActionGateError("receipt CID must match audited latest CID")
+    receipt_cids = ledger_audit.get("receipt_cids")
+
+    if not isinstance(receipt_cids, list):
+        raise CapitalActionGateError("ledger audit must include receipt CID membership list")
+
+    if receipt_cid not in receipt_cids:
+        raise CapitalActionGateError("receipt CID must be present in audited ledger")
 
     if ledger_audit.get("execution_authority") != "none":
         raise CapitalActionGateError("ledger audit execution authority must be none")

--- a/eve_q/receipt_ledger_audit.py
+++ b/eve_q/receipt_ledger_audit.py
@@ -89,6 +89,17 @@ def audit_receipt_ledger(ledger_path: Path) -> dict[str, Any]:
 
         expected_previous_cid = cid
 
+    receipt_events = [
+        {
+            "sequence": event.get("sequence"),
+            "cid": event.get("cid"),
+            "receipt_type": event.get("receipt_type"),
+            "previous_cid": event.get("previous_cid"),
+        }
+        for event in events
+    ]
+    receipt_cids = [event["cid"] for event in receipt_events if event.get("cid")]
+
     return {
         "schema": AUDIT_SCHEMA,
         "version": AUDIT_VERSION,
@@ -96,6 +107,8 @@ def audit_receipt_ledger(ledger_path: Path) -> dict[str, Any]:
         "event_count": len(events),
         "valid": not errors,
         "errors": errors,
+        "receipt_cids": receipt_cids,
+        "receipt_events": receipt_events,
         "latest_cid": expected_previous_cid,
         "execution_authority": "none",
         "artifact_is_command": False,

--- a/tests/test_capital_action_gate.py
+++ b/tests/test_capital_action_gate.py
@@ -138,6 +138,24 @@ def test_charity_completion_accepts_source_receipt_cid(tmp_path):
     assert certificate["source_receipt_cid"] == trade["cid"]
 
 
+def test_trade_completion_accepts_receipt_cid_present_but_not_latest(
+    tmp_path,
+):
+    ledger_path, trade, charity = build_trade_charity_ledger(tmp_path)
+    audit = audit_receipt_ledger(ledger_path)
+
+    certificate = build_completion_certificate(
+        action_kind=ACTION_TRADE,
+        target_status="SETTLED",
+        receipt_cid=trade["cid"],
+        ledger_audit=audit,
+    )
+
+    assert certificate["completion_status"] == "ACCOUNTED"
+    assert certificate["receipt_cid"] == trade["cid"]
+    assert certificate["ledger_latest_cid"] == charity["cid"]
+
+
 def test_rejects_missing_receipt_cid(tmp_path):
     ledger_path, trade = build_trade_ledger(tmp_path)
     audit = audit_receipt_ledger(ledger_path)


### PR DESCRIPTION
Allows capital completion gates to validate receipt CID membership in an audited ledger instead of requiring the receipt CID to equal the latest ledger CID.

Scope:
- adds receipt_cids membership list to receipt ledger audit packets
- adds receipt_events summaries to receipt ledger audit packets
- updates completion gate validation to require audited ledger membership
- preserves latest_cid as chain continuity metadata
- allows trade completion after a linked charity receipt has been appended
- keeps wrong or absent receipt CIDs rejected
- adds regression coverage for non-latest but valid receipt CIDs

Safety boundary:
- accounting/completion validation only
- does not execute trades
- does not send charity transactions
- no wallet access
- no transaction signing
- no autonomous capital movement
- no scheduler
- no webhook execution
- no shell execution
- artifacts remain records, not commands

Law:
The receipt need not be latest.
The receipt must be witnessed.
The audited ledger proves membership.
The chain remembers.
