### PR TITLE
Add public simulation demo

### DIFF
--- a/eve_q/demo_simulation.py
+++ b/eve_q/demo_simulation.py
@@ -1,0 +1,67 @@
+"""Public simulation demo for CodexTradingEngine.
+
+This demo proves the safe public claim:
+telemetry + simulation + audit artifact = yes
+live capital movement = no
+wallet signing = no
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+
+def build_demo_receipt() -> dict:
+    now = datetime.now(timezone.utc).isoformat()
+
+    return {
+        "schema": "codex.demo_simulation.v0.1",
+        "timestamp_utc": now,
+        "mode": "SIMULATION_ONLY",
+        "market_signal_observed": True,
+        "market_data_source": "demo_static_fixture",
+        "trade_candidate_simulated": True,
+        "candidate": {
+            "pair": "ETH/USDC",
+            "chain": "Base",
+            "direction": "observe_only",
+            "notional_usd": 0,
+        },
+        "risk_gate_evaluated": True,
+        "risk_gate_status": "PASS_FOR_SIMULATION_ONLY",
+        "charity_allocation_proposed": True,
+        "charity_allocation": {
+            "enabled": True,
+            "mode": "proposal_only",
+            "percent": 15,
+        },
+        "receipt_emitted": True,
+        "wallet_signing": False,
+        "capital_movement": False,
+        "autonomous_execution": False,
+        "mainnet_execution": False,
+        "artifact_is_command": False,
+        "summary": (
+            "Telemetry observed, candidate simulated, risk gate evaluated, "
+            "charity allocation proposed, receipt emitted. No funds moved."
+        ),
+    }
+
+
+def main() -> None:
+    receipt = build_demo_receipt()
+
+    print("market signal observed")
+    print("trade candidate simulated")
+    print("risk gate evaluated")
+    print("charity allocation proposed")
+    print("receipt emitted")
+    print("capital movement: false")
+    print("wallet signing: false")
+    print()
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_public_simulation_demo.py
+++ b/tests/test_public_simulation_demo.py
@@ -1,0 +1,47 @@
+import json
+
+from eve_q.demo_simulation import build_demo_receipt, main
+
+
+def test_public_demo_receipt_is_simulation_only():
+    receipt = build_demo_receipt()
+
+    assert receipt["schema"] == "codex.demo_simulation.v0.1"
+    assert receipt["mode"] == "SIMULATION_ONLY"
+
+    assert receipt["market_signal_observed"] is True
+    assert receipt["trade_candidate_simulated"] is True
+    assert receipt["risk_gate_evaluated"] is True
+    assert receipt["charity_allocation_proposed"] is True
+    assert receipt["receipt_emitted"] is True
+
+    assert receipt["wallet_signing"] is False
+    assert receipt["capital_movement"] is False
+    assert receipt["autonomous_execution"] is False
+    assert receipt["mainnet_execution"] is False
+    assert receipt["artifact_is_command"] is False
+
+    assert receipt["candidate"]["notional_usd"] == 0
+    assert receipt["charity_allocation"]["mode"] == "proposal_only"
+    assert receipt["charity_allocation"]["percent"] == 15
+
+
+def test_public_demo_outputs_safe_proof_handle(capsys):
+    main()
+
+    captured = capsys.readouterr().out
+
+    assert "market signal observed" in captured
+    assert "trade candidate simulated" in captured
+    assert "risk gate evaluated" in captured
+    assert "charity allocation proposed" in captured
+    assert "receipt emitted" in captured
+    assert "capital movement: false" in captured
+    assert "wallet signing: false" in captured
+
+    json_payload = captured.split("\n\n", 1)[1]
+    receipt = json.loads(json_payload)
+
+    assert receipt["mode"] == "SIMULATION_ONLY"
+    assert receipt["capital_movement"] is False
+    assert receipt["wallet_signing"] is False


### PR DESCRIPTION
Adds a public simulation demo command for CodexTradingEngine.

Command:
python -m eve_q.demo_simulation

The demo emits a safe proof handle showing:
- market signal observed
- trade candidate simulated
- risk gate evaluated
- charity allocation proposed
- receipt emitted
- capital movement: false
- wallet signing: false

Boundary:
- simulation only
- no wallet signing
- no capital movement
- no autonomous execution
- no mainnet execution
- artifact is not a command

Purpose:
This gives public reviewers a simple command to verify the current working claim:
telemetry + simulation + audit artifact works; live capital remains intentionally gated.
