### PR TITLE
Add isolated Rust repricing subprocess contract

### DIFF
--- a/.github/workflows/hybrid-delta-ci.yml
+++ b/.github/workflows/hybrid-delta-ci.yml
@@ -3,6 +3,7 @@ name: Hybrid Delta CI
 on:
   pull_request:
     paths:
+      - "README.md"
       - "eve_q/qaoa_delta.py"
       - "eve_q/qaoa_sampling.py"
       - "eve_q/rust_repricing.py"
@@ -10,6 +11,8 @@ on:
       - "tests/test_qaoa_sampling.py"
       - "tests/test_rust_repricing.py"
       - "rust/delta-verifier/**"
+      - "schemas/delta_repricing_request.schema.json"
+      - "schemas/delta_repricing_response.schema.json"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
       - "docs/QAOA_DELTA_PHASE_2B.md"
@@ -19,6 +22,7 @@ on:
     branches:
       - main
     paths:
+      - "README.md"
       - "eve_q/qaoa_delta.py"
       - "eve_q/qaoa_sampling.py"
       - "eve_q/rust_repricing.py"
@@ -26,6 +30,8 @@ on:
       - "tests/test_qaoa_sampling.py"
       - "tests/test_rust_repricing.py"
       - "rust/delta-verifier/**"
+      - "schemas/delta_repricing_request.schema.json"
+      - "schemas/delta_repricing_response.schema.json"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
       - "docs/QAOA_DELTA_PHASE_2B.md"

--- a/.github/workflows/hybrid-delta-ci.yml
+++ b/.github/workflows/hybrid-delta-ci.yml
@@ -5,11 +5,14 @@ on:
     paths:
       - "eve_q/qaoa_delta.py"
       - "eve_q/qaoa_sampling.py"
+      - "eve_q/rust_repricing.py"
       - "tests/test_qaoa_delta.py"
       - "tests/test_qaoa_sampling.py"
+      - "tests/test_rust_repricing.py"
       - "rust/delta-verifier/**"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
+      - "docs/QAOA_DELTA_PHASE_2B.md"
       - "pyproject.toml"
       - ".github/workflows/hybrid-delta-ci.yml"
   push:
@@ -18,11 +21,14 @@ on:
     paths:
       - "eve_q/qaoa_delta.py"
       - "eve_q/qaoa_sampling.py"
+      - "eve_q/rust_repricing.py"
       - "tests/test_qaoa_delta.py"
       - "tests/test_qaoa_sampling.py"
+      - "tests/test_rust_repricing.py"
       - "rust/delta-verifier/**"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
+      - "docs/QAOA_DELTA_PHASE_2B.md"
       - "pyproject.toml"
       - ".github/workflows/hybrid-delta-ci.yml"
 
@@ -49,13 +55,18 @@ jobs:
         run: python -m pip install -e '.[test]'
 
       - name: Compile hybrid delta core
-        run: python -m compileall -q eve_q/qaoa_delta.py eve_q/qaoa_sampling.py
+        run: |
+          python -m compileall -q \
+            eve_q/qaoa_delta.py \
+            eve_q/qaoa_sampling.py \
+            eve_q/rust_repricing.py
 
       - name: Run hybrid delta tests
         run: |
           python -m pytest \
             tests/test_qaoa_delta.py \
             tests/test_qaoa_sampling.py \
+            tests/test_rust_repricing.py \
             --no-cov -q
 
   qiskit-adapter:
@@ -113,3 +124,27 @@ jobs:
 
       - name: Run Rust tests
         run: cargo test --manifest-path rust/delta-verifier/Cargo.toml
+
+  bridge-integration:
+    name: Python to Rust repricing bridge
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Python test lane
+        run: python -m pip install -e '.[test]'
+
+      - name: Build isolated Rust verifier
+        run: cargo build --manifest-path rust/delta-verifier/Cargo.toml
+
+      - name: Exercise bounded subprocess contract
+        env:
+          CODEX_DELTA_VERIFIER_BIN: ${{ github.workspace }}/rust/delta-verifier/target/debug/codex-delta-verifier
+        run: python -m pytest tests/test_rust_repricing.py --no-cov -q

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ CodexTradingEngine may produce:
 - charity allocation proposals
 - CID-backed carrier manifests
 - QAOA-ready price-delta candidates
-- Rust verification reports
+- QAOA confidence receipts
+- Rust exact-repricing evidence
 
 These outputs are review artifacts. They are not commands.
 
@@ -88,17 +89,18 @@ Artifact carrier manifests can point to public, encrypted, or private payloads. 
 
 ```text
 Python constructs the market graph, QUBO, policy context, and receipts.
-Qiskit QAOA triangulates price-delta candidates.
-Rust performs exact route, fee, slippage, latency, and margin verification.
+Qiskit QAOA triangulates and samples price-delta candidates.
+Rust performs exact route, fee, slippage, latency, gas, and margin verification.
 Classical solvers remain available for fallback, benchmarking, and independent checks.
 ```
 
-The initial implementation is intentionally simulation-only and uses an at-most-one triangular-cycle selection QUBO. Qiskit is optional; the deterministic QUBO and classical fallback remain usable without it.
+The implementation is intentionally simulation-only. Qiskit performs bounded local sampling and emits confidence evidence. Python binds that evidence to a strict request and invokes an explicit local Rust verifier with `shell=False`. Rust independently reconstructs candidate identity, reprices the route, and returns `authority: false` evidence.
 
 ```text
 QAOA discovers the geometry of the opportunity.
 Rust confirms that the geometry still exists.
 Python controls what may happen with that knowledge.
+Human review remains the promotion gate.
 ```
 
 ## Status
@@ -128,9 +130,15 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | Receipt carrier attestation docs | `docs/receipt_carrier_attestation_example.md` | Documents attestation drift detection and non-execution boundaries. |
 | Membrane metadata extractor and attestation bridge | `eve_q/membrane_tool.py` | Extracts carrier manifests from PNG Comment metadata, validates carrier law, and can compare receipt attestations without execution authority. |
 | QAOA delta triangulation core | `eve_q/qaoa_delta.py` | Enumerates triangular price deltas, builds QUBO/Ising contracts, and provides a classical fallback with `authority: false`. |
+| QAOA sampling and confidence receipts | `eve_q/qaoa_sampling.py` | Performs bounded local sampling, deterministic decoding, and exact-baseline comparison. |
+| Python-to-Rust repricing bridge | `eve_q/rust_repricing.py` | Binds candidate evidence to a strict subprocess request and fails closed on protocol drift. |
 | Rust exact delta verifier | `rust/delta-verifier/` | Reprices a closed triangular route after fee, slippage, latency, gas, and margin assumptions without network access. |
+| Repricing request schema | `schemas/delta_repricing_request.schema.json` | Defines the strict hash-bound candidate request surface. |
+| Repricing response schema | `schemas/delta_repricing_response.schema.json` | Defines the strict exact-verification response surface. |
 | Hybrid delta architecture | `docs/QAOA_DELTA_TRIANGULATION_v0_1.md` | Defines Python, Qiskit, Rust, fallback, and authority boundaries. |
-| Hybrid delta CI | `.github/workflows/hybrid-delta-ci.yml` | Validates Python 3.11/3.13, Qiskit 2.5 ansatz construction, and stable Rust. |
+| Phase 2A architecture | `docs/QAOA_DELTA_PHASE_2A.md` | Defines bounded QAOA sampling and confidence receipts. |
+| Phase 2B architecture | `docs/QAOA_DELTA_PHASE_2B.md` | Defines the isolated Python-to-Rust exact-repricing contract. |
+| Hybrid delta CI | `.github/workflows/hybrid-delta-ci.yml` | Validates Python 3.11/3.13, Qiskit 2.5, stable Rust, and the real subprocess bridge. |
 
 Membrane bridge:
 
@@ -142,7 +150,7 @@ Chain:
 
 Hybrid delta chain:
 
-`market snapshot -> triangular cycles -> QUBO -> QAOA candidate -> Rust verification -> policy review -> simulation receipt`
+`market snapshot -> triangular cycles -> QUBO -> QAOA confidence receipt -> Rust exact repricing -> policy review -> simulation receipt`
 
 Current law:
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | Artifact carrier example docs | `docs/artifact_carrier_manifest_example.md` | Documents the carrier law: the artifact carries memory, not authority. |
 | Receipt carrier attestation validator | `eve_q/receipt_carrier_attestation.py` | Binds a receipt identifier to a carrier manifest digest and CID as a review artifact. |
 | Receipt carrier attestation example | `examples/receipt_carrier_attestation.example.json` | Demonstrates safe receipt-to-carrier attestation. |
-| Receipt carrier attestation docs | `docs/artifact_carrier_manifest_example.md` | Documents attestation drift detection and non-execution boundaries. |
+| Receipt carrier attestation docs | `docs/receipt_carrier_attestation_example.md` | Documents attestation drift detection and non-execution boundaries. |
 | Membrane metadata extractor and attestation bridge | `eve_q/membrane_tool.py` | Extracts carrier manifests from PNG Comment metadata, validates carrier law, and can compare receipt attestations without execution authority. |
 | QAOA delta triangulation core | `eve_q/qaoa_delta.py` | Enumerates triangular price deltas, builds QUBO/Ising contracts, and provides a classical fallback with `authority: false`. |
 | QAOA sampling and confidence receipts | `eve_q/qaoa_sampling.py` | Performs bounded local sampling, deterministic decoding, and exact-baseline comparison. |

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Classical solvers remain available for fallback, benchmarking, and independent c
 
 The implementation is intentionally simulation-only. Qiskit performs bounded local sampling and emits confidence evidence. Python binds that evidence to a strict request and invokes an explicit local Rust verifier with `shell=False`. Rust independently reconstructs candidate identity, reprices the route, and returns `authority: false` evidence.
 
+The complete Python → Rust subprocess path is exercised in CI against a real compiled verifier binary, including candidate-identity rejection and authority-boundary checks.
+
 ```text
 QAOA discovers the geometry of the opportunity.
 Rust confirms that the geometry still exists.
@@ -127,7 +129,7 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | Artifact carrier example docs | `docs/artifact_carrier_manifest_example.md` | Documents the carrier law: the artifact carries memory, not authority. |
 | Receipt carrier attestation validator | `eve_q/receipt_carrier_attestation.py` | Binds a receipt identifier to a carrier manifest digest and CID as a review artifact. |
 | Receipt carrier attestation example | `examples/receipt_carrier_attestation.example.json` | Demonstrates safe receipt-to-carrier attestation. |
-| Receipt carrier attestation docs | `docs/receipt_carrier_attestation_example.md` | Documents attestation drift detection and non-execution boundaries. |
+| Receipt carrier attestation docs | `docs/artifact_carrier_manifest_example.md` | Documents attestation drift detection and non-execution boundaries. |
 | Membrane metadata extractor and attestation bridge | `eve_q/membrane_tool.py` | Extracts carrier manifests from PNG Comment metadata, validates carrier law, and can compare receipt attestations without execution authority. |
 | QAOA delta triangulation core | `eve_q/qaoa_delta.py` | Enumerates triangular price deltas, builds QUBO/Ising contracts, and provides a classical fallback with `authority: false`. |
 | QAOA sampling and confidence receipts | `eve_q/qaoa_sampling.py` | Performs bounded local sampling, deterministic decoding, and exact-baseline comparison. |

--- a/docs/QAOA_DELTA_PHASE_2B.md
+++ b/docs/QAOA_DELTA_PHASE_2B.md
@@ -1,0 +1,98 @@
+# QAOA Delta Phase 2B — Isolated Rust Repricing Bridge
+
+Phase 2B turns a QAOA confidence receipt into an independently repriced market claim.
+It does not introduce live execution.
+
+## Compute lanes
+
+```text
+QAOA confidence receipt
+→ Python request builder
+→ strict JSON request
+→ isolated Rust verifier process
+→ strict JSON response
+→ Python response validation
+→ simulation evidence
+```
+
+- **Qiskit/QAOA** proposes candidate geometry.
+- **Rust** recomputes route closure, fees, slippage, latency penalty, gas penalty,
+  net multiplier, net log delta, and margin survival.
+- **Python** binds hashes, launches the explicit local verifier with `shell=False`,
+  enforces timeout and payload limits, validates the response, and records drift.
+- **Human review** remains the promotion gate.
+
+## Request binding
+
+Every request binds:
+
+- a stable `request_id`;
+- the market snapshot SHA-256;
+- the QUBO model SHA-256;
+- the originating QAOA confidence receipt;
+- the triangular candidate identifier;
+- exactly three ordered market edges;
+- gas and minimum-margin assumptions;
+- `authority: false`.
+
+The Rust verifier independently reconstructs the candidate identifier from the
+rotation-canonical edge sequence and rejects identity drift.
+
+## Process boundary
+
+The verifier:
+
+- reads at most 65,536 bytes from standard input;
+- accepts one strict JSON object with unknown fields rejected;
+- writes one deterministic JSON response to standard output;
+- writes a bounded machine-readable error to standard error on rejection;
+- performs no network, filesystem, wallet, RPC, signer, scheduler, or capital action.
+
+The Python bridge:
+
+- requires an absolute executable path;
+- invokes a single argument vector with `shell=False`;
+- applies a strict timeout;
+- rejects oversized output;
+- requires exact response keys;
+- verifies all request identity fields are echoed unchanged;
+- rejects any authority escalation;
+- fails closed on timeout, crash, malformed JSON, schema drift, or identity drift.
+
+## Evidence object
+
+Successful verification records:
+
+```text
+snapshot_sha256
+model_sha256
+confidence_receipt_id
+candidate_id
+verifier identity
+ordered edge identifiers
+asset path
+net multiplier
+net log delta
+minimum margin
+profitability
+margin survival
+proposal log delta
+verified delta drift
+authority: false
+```
+
+`delta_drift` is the difference between Rust's exact repricing result and the
+Python proposal. A zero drift is expected when both lanes consume the same
+snapshot and assumptions. Later phases may deliberately reprice against fresher
+or perturbed snapshots, where nonzero drift becomes a primary signal.
+
+## Promotion law
+
+```text
+QAOA may propose.
+Rust must reprice.
+Python must apply policy.
+Evidence may increase trust.
+Evidence cannot grant authority.
+Human review remains required before any capital touchpoint.
+```

--- a/eve_q/rust_repricing.py
+++ b/eve_q/rust_repricing.py
@@ -1,0 +1,337 @@
+"""Fail-closed Python bridge to the isolated Rust exact repricer.
+
+The bridge serializes one bounded candidate request, invokes one explicitly chosen
+local executable with ``shell=False``, and validates one deterministic response.
+It has no wallet, RPC, scheduler, network, or capital authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from eve_q.qaoa_delta import MarketEdge, TriangularCycle
+from eve_q.qaoa_sampling import QaoaConfidenceReceipt
+
+_REQUEST_SCHEMA = "delta-repricing-request-v0.1"
+_RESPONSE_SCHEMA = "delta-repricing-response-v0.1"
+_MAX_PAYLOAD_BYTES = 64 * 1024
+_MAX_OUTPUT_BYTES = 64 * 1024
+
+
+def _require_sha256(value: str, field_name: str) -> None:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{field_name} must be 64 lowercase hexadecimal characters")
+
+
+def _require_exact_keys(value: Mapping[str, object], expected: set[str], context: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(f"{context} keys mismatch; missing={missing}, extra={extra}")
+
+
+def _edge_dict(edge: MarketEdge) -> dict[str, object]:
+    return {
+        "edge_id": edge.edge_id,
+        "source_asset": edge.source_asset,
+        "target_asset": edge.target_asset,
+        "quoted_rate": edge.quoted_rate,
+        "fee_bps": edge.fee_bps,
+        "slippage_bps": edge.slippage_bps,
+        "latency_penalty_bps": edge.latency_penalty_bps,
+    }
+
+
+@dataclass(frozen=True)
+class RustRepricingRequest:
+    request_id: str
+    snapshot_sha256: str
+    model_sha256: str
+    confidence_receipt_id: str
+    candidate_id: str
+    edges: tuple[Mapping[str, object], Mapping[str, object], Mapping[str, object]]
+    gas_penalty_log: float
+    minimum_log_delta: float
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.request_id.startswith("delta-reprice:"):
+            raise ValueError("request_id must use the delta-reprice namespace")
+        _require_sha256(self.snapshot_sha256, "snapshot_sha256")
+        _require_sha256(self.model_sha256, "model_sha256")
+        if not self.confidence_receipt_id.startswith("qaoa-confidence:"):
+            raise ValueError("confidence_receipt_id must use the qaoa-confidence namespace")
+        if not self.candidate_id.startswith("triangle:"):
+            raise ValueError("candidate_id must use the triangle namespace")
+        if len(self.edges) != 3:
+            raise ValueError("exactly three edges are required")
+        if not math.isfinite(self.gas_penalty_log) or self.gas_penalty_log < 0.0:
+            raise ValueError("gas_penalty_log must be finite and non-negative")
+        if not math.isfinite(self.minimum_log_delta):
+            raise ValueError("minimum_log_delta must be finite")
+        if self.authority:
+            raise ValueError("repricing requests cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": _REQUEST_SCHEMA,
+            "request_id": self.request_id,
+            "snapshot_sha256": self.snapshot_sha256,
+            "model_sha256": self.model_sha256,
+            "confidence_receipt_id": self.confidence_receipt_id,
+            "candidate_id": self.candidate_id,
+            "edges": [dict(edge) for edge in self.edges],
+            "gas_penalty_log": self.gas_penalty_log,
+            "minimum_log_delta": self.minimum_log_delta,
+            "authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class RustRepricingEvidence:
+    request_id: str
+    snapshot_sha256: str
+    model_sha256: str
+    confidence_receipt_id: str
+    candidate_id: str
+    verifier: str
+    status: str
+    edge_ids: tuple[str, str, str]
+    asset_path: tuple[str, str, str, str]
+    net_multiplier: float
+    net_log_delta: float
+    minimum_log_delta: float
+    profitable: bool
+    passes_margin: bool
+    proposal_log_delta: float
+    delta_drift: float
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if self.status != "verified":
+            raise ValueError("Rust repricing status must be verified")
+        for field_name, value in (
+            ("net_multiplier", self.net_multiplier),
+            ("net_log_delta", self.net_log_delta),
+            ("minimum_log_delta", self.minimum_log_delta),
+            ("proposal_log_delta", self.proposal_log_delta),
+            ("delta_drift", self.delta_drift),
+        ):
+            if not math.isfinite(value):
+                raise ValueError(f"{field_name} must be finite")
+        if self.authority:
+            raise ValueError("Rust repricing evidence cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": _RESPONSE_SCHEMA,
+            "request_id": self.request_id,
+            "snapshot_sha256": self.snapshot_sha256,
+            "model_sha256": self.model_sha256,
+            "confidence_receipt_id": self.confidence_receipt_id,
+            "candidate_id": self.candidate_id,
+            "verifier": self.verifier,
+            "status": self.status,
+            "verification": {
+                "edge_ids": list(self.edge_ids),
+                "asset_path": list(self.asset_path),
+                "net_multiplier": self.net_multiplier,
+                "net_log_delta": self.net_log_delta,
+                "minimum_log_delta": self.minimum_log_delta,
+                "profitable": self.profitable,
+                "passes_margin": self.passes_margin,
+                "authority": False,
+            },
+            "proposal_log_delta": self.proposal_log_delta,
+            "delta_drift": self.delta_drift,
+            "authority": False,
+        }
+
+
+def build_repricing_request(
+    receipt: QaoaConfidenceReceipt,
+    candidate: TriangularCycle,
+    market_edges: Sequence[MarketEdge],
+    *,
+    snapshot_sha256: str,
+    minimum_log_delta: float,
+) -> RustRepricingRequest:
+    """Bind a QAOA confidence receipt to one exact-repricing request."""
+
+    _require_sha256(snapshot_sha256, "snapshot_sha256")
+    if candidate.candidate_id not in receipt.best_sample.selected_candidate_ids:
+        raise ValueError("candidate must be selected by the confidence receipt best sample")
+
+    edges_by_id = {edge.edge_id: edge for edge in market_edges}
+    if len(edges_by_id) != len(market_edges):
+        raise ValueError("market edge identifiers must be unique")
+    try:
+        ordered_edges = tuple(_edge_dict(edges_by_id[edge_id]) for edge_id in candidate.edge_ids)
+    except KeyError as exc:
+        raise ValueError(f"candidate references missing market edge {exc.args[0]!r}") from exc
+
+    seed = {
+        "snapshot_sha256": snapshot_sha256,
+        "model_sha256": receipt.model_sha256,
+        "confidence_receipt_id": receipt.receipt_id,
+        "candidate_id": candidate.candidate_id,
+        "edges": ordered_edges,
+        "gas_penalty_log": candidate.gas_penalty_log,
+        "minimum_log_delta": minimum_log_delta,
+        "authority": False,
+    }
+    encoded = json.dumps(seed, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    request_hash = hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    return RustRepricingRequest(
+        request_id=f"delta-reprice:{request_hash[:24]}",
+        snapshot_sha256=snapshot_sha256,
+        model_sha256=receipt.model_sha256,
+        confidence_receipt_id=receipt.receipt_id,
+        candidate_id=candidate.candidate_id,
+        edges=ordered_edges,  # type: ignore[arg-type]
+        gas_penalty_log=candidate.gas_penalty_log,
+        minimum_log_delta=minimum_log_delta,
+    )
+
+
+def run_rust_repricing(
+    request: RustRepricingRequest,
+    candidate: TriangularCycle,
+    *,
+    executable: str | Path,
+    timeout_seconds: float = 2.0,
+) -> RustRepricingEvidence:
+    """Run the exact repricer once and fail closed on every protocol deviation."""
+
+    executable_path = Path(executable)
+    if not executable_path.is_absolute():
+        raise ValueError("Rust verifier executable path must be absolute")
+    if not executable_path.is_file():
+        raise ValueError("Rust verifier executable does not exist")
+    if timeout_seconds <= 0.0 or not math.isfinite(timeout_seconds):
+        raise ValueError("timeout_seconds must be finite and positive")
+
+    payload = json.dumps(
+        request.as_dict(), sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    if len(payload) > _MAX_PAYLOAD_BYTES:
+        raise ValueError("repricing request exceeds the 65536-byte protocol limit")
+
+    try:
+        completed = subprocess.run(
+            [str(executable_path)],
+            input=payload,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=timeout_seconds,
+            shell=False,
+            close_fds=True,
+            cwd=executable_path.parent,
+            env={"PATH": os.environ.get("PATH", "")},
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("Rust repricing timed out; candidate rejected") from exc
+
+    if len(completed.stdout) > _MAX_OUTPUT_BYTES or len(completed.stderr) > _MAX_OUTPUT_BYTES:
+        raise RuntimeError("Rust repricing output exceeded the protocol limit")
+    if completed.returncode != 0:
+        message = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"Rust repricing rejected the request: {message[:1000]}")
+
+    try:
+        response = json.loads(completed.stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("Rust repricing returned malformed JSON") from exc
+    if not isinstance(response, dict):
+        raise RuntimeError("Rust repricing response must be a JSON object")
+
+    _require_exact_keys(
+        response,
+        {
+            "schema_version",
+            "request_id",
+            "snapshot_sha256",
+            "model_sha256",
+            "confidence_receipt_id",
+            "candidate_id",
+            "verifier",
+            "status",
+            "verification",
+            "authority",
+        },
+        "repricing response",
+    )
+    if response["schema_version"] != _RESPONSE_SCHEMA:
+        raise RuntimeError("Rust repricing response schema mismatch")
+    for field_name in (
+        "request_id",
+        "snapshot_sha256",
+        "model_sha256",
+        "confidence_receipt_id",
+        "candidate_id",
+    ):
+        if response[field_name] != request.as_dict()[field_name]:
+            raise RuntimeError(f"Rust repricing response changed {field_name}")
+    if response["authority"] is not False:
+        raise RuntimeError("Rust repricing response attempted authority escalation")
+    if not isinstance(response["verifier"], str) or not response["verifier"].startswith(
+        "codex-delta-verifier/"
+    ):
+        raise RuntimeError("Rust repricing verifier identity is invalid")
+    if response["status"] != "verified":
+        raise RuntimeError("Rust repricing did not complete verification")
+
+    verification = response["verification"]
+    if not isinstance(verification, dict):
+        raise RuntimeError("verification must be a JSON object")
+    _require_exact_keys(
+        verification,
+        {
+            "edge_ids",
+            "asset_path",
+            "net_multiplier",
+            "net_log_delta",
+            "minimum_log_delta",
+            "profitable",
+            "passes_margin",
+            "authority",
+        },
+        "verification",
+    )
+    if verification["authority"] is not False:
+        raise RuntimeError("Rust verification attempted authority escalation")
+    if tuple(verification["edge_ids"]) != candidate.edge_ids:
+        raise RuntimeError("Rust verification changed the candidate edge order")
+    if tuple(verification["asset_path"]) != candidate.asset_path:
+        raise RuntimeError("Rust verification changed the candidate asset path")
+
+    net_log_delta = float(verification["net_log_delta"])
+    evidence = RustRepricingEvidence(
+        request_id=str(response["request_id"]),
+        snapshot_sha256=str(response["snapshot_sha256"]),
+        model_sha256=str(response["model_sha256"]),
+        confidence_receipt_id=str(response["confidence_receipt_id"]),
+        candidate_id=str(response["candidate_id"]),
+        verifier=str(response["verifier"]),
+        status=str(response["status"]),
+        edge_ids=tuple(str(value) for value in verification["edge_ids"]),  # type: ignore[arg-type]
+        asset_path=tuple(str(value) for value in verification["asset_path"]),  # type: ignore[arg-type]
+        net_multiplier=float(verification["net_multiplier"]),
+        net_log_delta=net_log_delta,
+        minimum_log_delta=float(verification["minimum_log_delta"]),
+        profitable=bool(verification["profitable"]),
+        passes_margin=bool(verification["passes_margin"]),
+        proposal_log_delta=candidate.net_log_delta,
+        delta_drift=net_log_delta - candidate.net_log_delta,
+    )
+    return evidence

--- a/rust/delta-verifier/Cargo.toml
+++ b/rust/delta-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-delta-verifier"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Pure Rust exact verifier for simulation-only triangular arbitrage candidates"
@@ -8,6 +8,14 @@ description = "Pure Rust exact verifier for simulation-only triangular arbitrage
 [lib]
 name = "codex_delta_verifier"
 path = "src/lib.rs"
+
+[[bin]]
+name = "codex-delta-verifier"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/rust/delta-verifier/Cargo.toml
+++ b/rust/delta-verifier/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/rust/delta-verifier/src/lib.rs
+++ b/rust/delta-verifier/src/lib.rs
@@ -1,12 +1,18 @@
 #![forbid(unsafe_code)]
 
-//! Exact, dependency-free verification for simulation-only triangular routes.
-//! The crate performs arithmetic only. It cannot access networks, wallets,
-//! signers, schedulers, or capital.
+//! Exact verification for simulation-only triangular routes.
+//! The crate performs bounded arithmetic and deterministic JSON protocol work.
+//! It cannot access networks, wallets, signers, schedulers, or capital.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 const BPS: f64 = 10_000.0;
+const REQUEST_SCHEMA: &str = "delta-repricing-request-v0.1";
+const RESPONSE_SCHEMA: &str = "delta-repricing-response-v0.1";
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EdgeQuote {
     pub edge_id: String,
     pub source_asset: String,
@@ -51,7 +57,8 @@ impl EdgeQuote {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CycleVerification {
     pub edge_ids: [String; 3],
     pub asset_path: [String; 4],
@@ -63,18 +70,54 @@ pub struct CycleVerification {
     pub authority: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepricingRequest {
+    pub schema_version: String,
+    pub request_id: String,
+    pub snapshot_sha256: String,
+    pub model_sha256: String,
+    pub confidence_receipt_id: String,
+    pub candidate_id: String,
+    pub edges: [EdgeQuote; 3],
+    pub gas_penalty_log: f64,
+    pub minimum_log_delta: f64,
+    pub authority: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RepricingResponse {
+    pub schema_version: String,
+    pub request_id: String,
+    pub snapshot_sha256: String,
+    pub model_sha256: String,
+    pub confidence_receipt_id: String,
+    pub candidate_id: String,
+    pub verifier: String,
+    pub status: String,
+    pub verification: CycleVerification,
+    pub authority: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VerificationError {
+    InvalidAuthority(String),
+    InvalidHash(String),
     InvalidNumber(String),
     InvalidRoute(String),
+    InvalidSchema(String),
     MissingField(String),
 }
 
 impl std::fmt::Display for VerificationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::InvalidNumber(message)
+            Self::InvalidAuthority(message)
+            | Self::InvalidHash(message)
+            | Self::InvalidNumber(message)
             | Self::InvalidRoute(message)
+            | Self::InvalidSchema(message)
             | Self::MissingField(message) => formatter.write_str(message),
         }
     }
@@ -89,6 +132,31 @@ fn validate_nonempty(value: &str, field: &str) -> Result<(), VerificationError> 
         )));
     }
     Ok(())
+}
+
+fn validate_sha256(value: &str, field: &str) -> Result<(), VerificationError> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()) {
+        return Err(VerificationError::InvalidHash(format!(
+            "{field} must be 64 lowercase hexadecimal characters"
+        )));
+    }
+    Ok(())
+}
+
+fn expected_candidate_id(edges: &[EdgeQuote; 3]) -> String {
+    let ids = [
+        edges[0].edge_id.as_str(),
+        edges[1].edge_id.as_str(),
+        edges[2].edge_id.as_str(),
+    ];
+    let seeds = [
+        format!("{}|{}|{}", ids[0], ids[1], ids[2]),
+        format!("{}|{}|{}", ids[1], ids[2], ids[0]),
+        format!("{}|{}|{}", ids[2], ids[0], ids[1]),
+    ];
+    let canonical = seeds.iter().min().expect("three rotations always exist");
+    let digest = format!("{:x}", Sha256::digest(canonical.as_bytes()));
+    format!("triangle:{}", &digest[..20])
 }
 
 pub fn verify_triangle(
@@ -128,6 +196,13 @@ pub fn verify_triangle(
         ));
     }
 
+    let edge_ids = [first.edge_id.as_str(), second.edge_id.as_str(), third.edge_id.as_str()];
+    if edge_ids[0] == edge_ids[1] || edge_ids[0] == edge_ids[2] || edge_ids[1] == edge_ids[2] {
+        return Err(VerificationError::InvalidRoute(
+            "triangle requires three distinct edge identifiers".to_string(),
+        ));
+    }
+
     let net_multiplier = first.effective_rate()?
         * second.effective_rate()?
         * third.effective_rate()?;
@@ -154,6 +229,60 @@ pub fn verify_triangle(
     })
 }
 
+pub fn verify_repricing_request(
+    request: &RepricingRequest,
+) -> Result<RepricingResponse, VerificationError> {
+    if request.schema_version != REQUEST_SCHEMA {
+        return Err(VerificationError::InvalidSchema(format!(
+            "schema_version must be {REQUEST_SCHEMA}"
+        )));
+    }
+    validate_nonempty(&request.request_id, "request_id")?;
+    if !request.request_id.starts_with("delta-reprice:") {
+        return Err(VerificationError::InvalidSchema(
+            "request_id must use the delta-reprice namespace".to_string(),
+        ));
+    }
+    validate_sha256(&request.snapshot_sha256, "snapshot_sha256")?;
+    validate_sha256(&request.model_sha256, "model_sha256")?;
+    if !request.confidence_receipt_id.starts_with("qaoa-confidence:") {
+        return Err(VerificationError::InvalidSchema(
+            "confidence_receipt_id must use the qaoa-confidence namespace".to_string(),
+        ));
+    }
+    if request.authority {
+        return Err(VerificationError::InvalidAuthority(
+            "repricing requests cannot grant authority".to_string(),
+        ));
+    }
+
+    let expected = expected_candidate_id(&request.edges);
+    if request.candidate_id != expected {
+        return Err(VerificationError::InvalidHash(format!(
+            "candidate_id mismatch: expected {expected}"
+        )));
+    }
+
+    let verification = verify_triangle(
+        [&request.edges[0], &request.edges[1], &request.edges[2]],
+        request.gas_penalty_log,
+        request.minimum_log_delta,
+    )?;
+
+    Ok(RepricingResponse {
+        schema_version: RESPONSE_SCHEMA.to_string(),
+        request_id: request.request_id.clone(),
+        snapshot_sha256: request.snapshot_sha256.clone(),
+        model_sha256: request.model_sha256.clone(),
+        confidence_receipt_id: request.confidence_receipt_id.clone(),
+        candidate_id: request.candidate_id.clone(),
+        verifier: "codex-delta-verifier/0.2.0".to_string(),
+        status: "verified".to_string(),
+        verification,
+        authority: false,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -170,6 +299,26 @@ mod tests {
         }
     }
 
+    fn request() -> RepricingRequest {
+        let edges = [
+            edge("usd-eth", "USD", "ETH", 0.0005),
+            edge("eth-btc", "ETH", "BTC", 0.05),
+            edge("btc-usd", "BTC", "USD", 41_000.0),
+        ];
+        RepricingRequest {
+            schema_version: REQUEST_SCHEMA.to_string(),
+            request_id: "delta-reprice:test".to_string(),
+            snapshot_sha256: "a".repeat(64),
+            model_sha256: "b".repeat(64),
+            confidence_receipt_id: "qaoa-confidence:test".to_string(),
+            candidate_id: expected_candidate_id(&edges),
+            edges,
+            gas_penalty_log: 0.0,
+            minimum_log_delta: 0.01,
+            authority: false,
+        }
+    }
+
     #[test]
     fn verifies_profitable_triangle_without_authority() {
         let first = edge("usd-eth", "USD", "ETH", 0.0005);
@@ -182,6 +331,44 @@ mod tests {
         assert!(result.profitable);
         assert!(result.passes_margin);
         assert!(!result.authority);
+    }
+
+    #[test]
+    fn repricing_protocol_binds_candidate_and_hashes() {
+        let response = verify_repricing_request(&request()).unwrap();
+
+        assert_eq!(response.status, "verified");
+        assert_eq!(response.snapshot_sha256, "a".repeat(64));
+        assert!(response.verification.passes_margin);
+        assert!(!response.authority);
+        assert!(!response.verification.authority);
+    }
+
+    #[test]
+    fn repricing_protocol_rejects_candidate_identity_drift() {
+        let mut altered = request();
+        altered.candidate_id = "triangle:00000000000000000000".to_string();
+
+        let error = verify_repricing_request(&altered).unwrap_err();
+        assert!(matches!(error, VerificationError::InvalidHash(_)));
+    }
+
+    #[test]
+    fn repricing_protocol_rejects_authority_escalation() {
+        let mut altered = request();
+        altered.authority = true;
+
+        let error = verify_repricing_request(&altered).unwrap_err();
+        assert!(matches!(error, VerificationError::InvalidAuthority(_)));
+    }
+
+    #[test]
+    fn strict_json_rejects_unknown_fields() {
+        let mut value = serde_json::to_value(request()).unwrap();
+        value["wallet"] = serde_json::json!("forbidden");
+
+        let error = serde_json::from_value::<RepricingRequest>(value).unwrap_err();
+        assert!(error.to_string().contains("unknown field"));
     }
 
     #[test]

--- a/rust/delta-verifier/src/main.rs
+++ b/rust/delta-verifier/src/main.rs
@@ -1,0 +1,46 @@
+#![forbid(unsafe_code)]
+
+use codex_delta_verifier::{verify_repricing_request, RepricingRequest};
+use serde_json::json;
+use std::io::{self, Read};
+
+const MAX_INPUT_BYTES: usize = 64 * 1024;
+
+fn fail(kind: &str, message: &str) -> ! {
+    let payload = json!({
+        "schema_version": "delta-repricing-error-v0.1",
+        "kind": kind,
+        "message": message,
+        "authority": false
+    });
+    eprintln!("{}", serde_json::to_string(&payload).expect("error JSON is serializable"));
+    std::process::exit(2);
+}
+
+fn main() {
+    let mut input = Vec::new();
+    if let Err(error) = io::stdin()
+        .take((MAX_INPUT_BYTES + 1) as u64)
+        .read_to_end(&mut input)
+    {
+        fail("stdin_read_failed", &error.to_string());
+    }
+    if input.len() > MAX_INPUT_BYTES {
+        fail("payload_too_large", "request exceeds 65536 bytes");
+    }
+
+    let request: RepricingRequest = match serde_json::from_slice(&input) {
+        Ok(request) => request,
+        Err(error) => fail("invalid_request_json", &error.to_string()),
+    };
+
+    let response = match verify_repricing_request(&request) {
+        Ok(response) => response,
+        Err(error) => fail("verification_rejected", &error.to_string()),
+    };
+
+    match serde_json::to_string(&response) {
+        Ok(encoded) => println!("{encoded}"),
+        Err(error) => fail("response_serialization_failed", &error.to_string()),
+    }
+}

--- a/schemas/delta_repricing_request.schema.json
+++ b/schemas/delta_repricing_request.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spiralbloom.local/schemas/delta_repricing_request.schema.json",
+  "title": "Delta Repricing Request v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "request_id",
+    "snapshot_sha256",
+    "model_sha256",
+    "confidence_receipt_id",
+    "candidate_id",
+    "edges",
+    "gas_penalty_log",
+    "minimum_log_delta",
+    "authority"
+  ],
+  "properties": {
+    "schema_version": {"const": "delta-repricing-request-v0.1"},
+    "request_id": {"type": "string", "pattern": "^delta-reprice:[0-9a-f]{24}$"},
+    "snapshot_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "model_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "confidence_receipt_id": {"type": "string", "pattern": "^qaoa-confidence:"},
+    "candidate_id": {"type": "string", "pattern": "^triangle:[0-9a-f]{20}$"},
+    "edges": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "edge_id",
+          "source_asset",
+          "target_asset",
+          "quoted_rate",
+          "fee_bps",
+          "slippage_bps",
+          "latency_penalty_bps"
+        ],
+        "properties": {
+          "edge_id": {"type": "string", "minLength": 1},
+          "source_asset": {"type": "string", "minLength": 1},
+          "target_asset": {"type": "string", "minLength": 1},
+          "quoted_rate": {"type": "number", "exclusiveMinimum": 0},
+          "fee_bps": {"type": "number", "minimum": 0, "exclusiveMaximum": 10000},
+          "slippage_bps": {"type": "number", "minimum": 0, "exclusiveMaximum": 10000},
+          "latency_penalty_bps": {"type": "number", "minimum": 0, "exclusiveMaximum": 10000}
+        }
+      }
+    },
+    "gas_penalty_log": {"type": "number", "minimum": 0},
+    "minimum_log_delta": {"type": "number"},
+    "authority": {"const": false}
+  }
+}

--- a/schemas/delta_repricing_response.schema.json
+++ b/schemas/delta_repricing_response.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spiralbloom.local/schemas/delta_repricing_response.schema.json",
+  "title": "Delta Repricing Response v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "request_id",
+    "snapshot_sha256",
+    "model_sha256",
+    "confidence_receipt_id",
+    "candidate_id",
+    "verifier",
+    "status",
+    "verification",
+    "authority"
+  ],
+  "properties": {
+    "schema_version": {"const": "delta-repricing-response-v0.1"},
+    "request_id": {"type": "string", "pattern": "^delta-reprice:[0-9a-f]{24}$"},
+    "snapshot_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "model_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "confidence_receipt_id": {"type": "string", "pattern": "^qaoa-confidence:"},
+    "candidate_id": {"type": "string", "pattern": "^triangle:[0-9a-f]{20}$"},
+    "verifier": {"type": "string", "pattern": "^codex-delta-verifier/"},
+    "status": {"const": "verified"},
+    "verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "edge_ids",
+        "asset_path",
+        "net_multiplier",
+        "net_log_delta",
+        "minimum_log_delta",
+        "profitable",
+        "passes_margin",
+        "authority"
+      ],
+      "properties": {
+        "edge_ids": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "asset_path": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "net_multiplier": {"type": "number", "exclusiveMinimum": 0},
+        "net_log_delta": {"type": "number"},
+        "minimum_log_delta": {"type": "number"},
+        "profitable": {"type": "boolean"},
+        "passes_margin": {"type": "boolean"},
+        "authority": {"const": false}
+      }
+    },
+    "authority": {"const": false}
+  }
+}

--- a/tests/test_rust_repricing.py
+++ b/tests/test_rust_repricing.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from eve_q.qaoa_delta import (
+    MarketEdge,
+    build_cycle_selection_qubo,
+    enumerate_triangular_cycles,
+)
+from eve_q.qaoa_sampling import build_qaoa_confidence_receipt
+from eve_q.rust_repricing import build_repricing_request, run_rust_repricing
+
+
+def _fixture():
+    edges = (
+        MarketEdge("usd-eth", "USD", "ETH", 0.0005, venue="alpha"),
+        MarketEdge("eth-btc", "ETH", "BTC", 0.05, venue="beta"),
+        MarketEdge("btc-usd", "BTC", "USD", 41_000.0, venue="gamma"),
+    )
+    candidate = enumerate_triangular_cycles(edges)[0]
+    model = build_cycle_selection_qubo((candidate,))
+    receipt = build_qaoa_confidence_receipt(
+        model,
+        (candidate,),
+        {"1": 1.0},
+        solver="test-distribution",
+        reps=1,
+    )
+    return edges, candidate, receipt
+
+
+def test_builds_deterministic_hash_bound_request() -> None:
+    edges, candidate, receipt = _fixture()
+
+    first = build_repricing_request(
+        receipt,
+        candidate,
+        edges,
+        snapshot_sha256="c" * 64,
+        minimum_log_delta=0.01,
+    )
+    second = build_repricing_request(
+        receipt,
+        candidate,
+        edges,
+        snapshot_sha256="c" * 64,
+        minimum_log_delta=0.01,
+    )
+
+    assert first == second
+    assert first.request_id.startswith("delta-reprice:")
+    assert first.candidate_id == candidate.candidate_id
+    assert first.model_sha256 == receipt.model_sha256
+    assert first.authority is False
+
+
+def test_rejects_candidate_not_selected_by_confidence_receipt() -> None:
+    edges, candidate, receipt = _fixture()
+    unselected = build_qaoa_confidence_receipt(
+        build_cycle_selection_qubo((candidate,)),
+        (candidate,),
+        {"0": 1.0},
+        solver="test-distribution",
+        reps=1,
+    )
+
+    with pytest.raises(ValueError, match="must be selected"):
+        build_repricing_request(
+            unselected,
+            candidate,
+            edges,
+            snapshot_sha256="c" * 64,
+            minimum_log_delta=0.01,
+        )
+
+
+def test_requires_absolute_explicit_executable() -> None:
+    edges, candidate, receipt = _fixture()
+    request = build_repricing_request(
+        receipt,
+        candidate,
+        edges,
+        snapshot_sha256="c" * 64,
+        minimum_log_delta=0.01,
+    )
+
+    with pytest.raises(ValueError, match="must be absolute"):
+        run_rust_repricing(
+            request,
+            candidate,
+            executable="codex-delta-verifier",
+        )
+
+
+def test_real_rust_subprocess_round_trip_when_binary_is_provided() -> None:
+    binary = os.environ.get("CODEX_DELTA_VERIFIER_BIN")
+    if not binary:
+        pytest.skip("Rust verifier binary not provided")
+
+    edges, candidate, receipt = _fixture()
+    request = build_repricing_request(
+        receipt,
+        candidate,
+        edges,
+        snapshot_sha256="c" * 64,
+        minimum_log_delta=0.01,
+    )
+
+    evidence = run_rust_repricing(
+        request,
+        candidate,
+        executable=Path(binary).resolve(),
+    )
+
+    assert evidence.status == "verified"
+    assert evidence.passes_margin is True
+    assert evidence.net_log_delta == pytest.approx(candidate.net_log_delta)
+    assert evidence.delta_drift == pytest.approx(0.0)
+    assert evidence.authority is False
+
+
+def test_real_rust_subprocess_rejects_candidate_identity_drift() -> None:
+    binary = os.environ.get("CODEX_DELTA_VERIFIER_BIN")
+    if not binary:
+        pytest.skip("Rust verifier binary not provided")
+
+    edges, candidate, receipt = _fixture()
+    request = build_repricing_request(
+        receipt,
+        candidate,
+        edges,
+        snapshot_sha256="c" * 64,
+        minimum_log_delta=0.01,
+    )
+    altered = replace(request, candidate_id="triangle:00000000000000000000")
+
+    with pytest.raises(RuntimeError, match="rejected the request"):
+        run_rust_repricing(
+            altered,
+            candidate,
+            executable=Path(binary).resolve(),
+        )


### PR DESCRIPTION
## Summary

Implements Phase 2B of the hybrid delta engine: a fail-closed Python → Rust exact-repricing boundary for QAOA-selected triangular candidates.

## Included

- strict JSON request and response contracts
- rotation-canonical candidate identity verification in Rust
- snapshot, QUBO model, confidence receipt, and candidate hash binding
- exact fee, slippage, latency, gas, route, and margin recalculation
- bounded stdin/stdout Rust CLI
- absolute-path Python invocation with `shell=False`
- timeout, payload, output, schema, identity, and authority checks
- proposal-versus-verification delta drift evidence
- JSON Schemas and architecture documentation
- Python, Rust, and real subprocess integration tests
- canonical README surface for the complete hybrid lane

## Design law

```text
QAOA may propose.
Rust must reprice.
Python must apply policy.
Evidence may increase trust.
Evidence cannot grant authority.
Human review remains required before any capital touchpoint.
```

## GitHub validation

All dedicated Phase 2B gates passed on the current head:

- Python 3.11 hybrid core: PASS
- Python 3.13 hybrid core: PASS
- Qiskit 2.5 local sampling: PASS
- Rust exact verifier: PASS
- real Python → compiled Rust subprocess round trip: PASS
- candidate identity drift rejection: PASS

## Boundaries

- no wallet or transaction signing
- no RPC submission
- no network access in the verifier
- no flash-loan borrowing
- no mempool mutation
- no scheduler authority
- no autonomous capital movement
- all requests, responses, and evidence retain `authority: false`

## Scope

This PR implements Phase 2B only. Perturbed-state robustness, flash-liquidity variables, benchmark corpus, canonical run receipts, and SpiralBloom advisory ingestion remain later bounded phases tracked by issue #48.

## Human gate

The branch is validated and ready for review. No live execution authority is introduced.