### PR TITLE
Add perturbed-state robustness evidence

### DIFF
--- a/.github/workflows/hybrid-delta-ci.yml
+++ b/.github/workflows/hybrid-delta-ci.yml
@@ -7,15 +7,19 @@ on:
       - "eve_q/qaoa_delta.py"
       - "eve_q/qaoa_sampling.py"
       - "eve_q/rust_repricing.py"
+      - "eve_q/delta_robustness.py"
       - "tests/test_qaoa_delta.py"
       - "tests/test_qaoa_sampling.py"
       - "tests/test_rust_repricing.py"
+      - "tests/test_delta_robustness.py"
       - "rust/delta-verifier/**"
       - "schemas/delta_repricing_request.schema.json"
       - "schemas/delta_repricing_response.schema.json"
+      - "schemas/delta_robustness_receipt.schema.json"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
       - "docs/QAOA_DELTA_PHASE_2B.md"
+      - "docs/QAOA_DELTA_PHASE_2C1.md"
       - "pyproject.toml"
       - ".github/workflows/hybrid-delta-ci.yml"
   push:
@@ -26,15 +30,19 @@ on:
       - "eve_q/qaoa_delta.py"
       - "eve_q/qaoa_sampling.py"
       - "eve_q/rust_repricing.py"
+      - "eve_q/delta_robustness.py"
       - "tests/test_qaoa_delta.py"
       - "tests/test_qaoa_sampling.py"
       - "tests/test_rust_repricing.py"
+      - "tests/test_delta_robustness.py"
       - "rust/delta-verifier/**"
       - "schemas/delta_repricing_request.schema.json"
       - "schemas/delta_repricing_response.schema.json"
+      - "schemas/delta_robustness_receipt.schema.json"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
       - "docs/QAOA_DELTA_PHASE_2B.md"
+      - "docs/QAOA_DELTA_PHASE_2C1.md"
       - "pyproject.toml"
       - ".github/workflows/hybrid-delta-ci.yml"
 
@@ -65,7 +73,11 @@ jobs:
           python -m compileall -q \
             eve_q/qaoa_delta.py \
             eve_q/qaoa_sampling.py \
-            eve_q/rust_repricing.py
+            eve_q/rust_repricing.py \
+            eve_q/delta_robustness.py
+
+      - name: Validate robustness schema syntax
+        run: python -m json.tool schemas/delta_robustness_receipt.schema.json >/dev/null
 
       - name: Run hybrid delta tests
         run: |
@@ -73,6 +85,7 @@ jobs:
             tests/test_qaoa_delta.py \
             tests/test_qaoa_sampling.py \
             tests/test_rust_repricing.py \
+            tests/test_delta_robustness.py \
             --no-cov -q
 
   qiskit-adapter:
@@ -132,7 +145,7 @@ jobs:
         run: cargo test --manifest-path rust/delta-verifier/Cargo.toml
 
   bridge-integration:
-    name: Python to Rust repricing bridge
+    name: Python to Rust repricing and robustness bridge
     runs-on: ubuntu-latest
 
     steps:
@@ -150,7 +163,11 @@ jobs:
       - name: Build isolated Rust verifier
         run: cargo build --manifest-path rust/delta-verifier/Cargo.toml
 
-      - name: Exercise bounded subprocess contract
+      - name: Exercise bounded subprocess and robustness contracts
         env:
           CODEX_DELTA_VERIFIER_BIN: ${{ github.workspace }}/rust/delta-verifier/target/debug/codex-delta-verifier
-        run: python -m pytest tests/test_rust_repricing.py --no-cov -q
+        run: |
+          python -m pytest \
+            tests/test_rust_repricing.py \
+            tests/test_delta_robustness.py \
+            --no-cov -q

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ CodexTradingEngine may produce:
 - QAOA-ready price-delta candidates
 - QAOA confidence receipts
 - Rust exact-repricing evidence
+- perturbed-state robustness receipts
 
 These outputs are review artifacts. They are not commands.
 
@@ -96,11 +97,14 @@ Classical solvers remain available for fallback, benchmarking, and independent c
 
 The implementation is intentionally simulation-only. Qiskit performs bounded local sampling and emits confidence evidence. Python binds that evidence to a strict request and invokes an explicit local Rust verifier with `shell=False`. Rust independently reconstructs candidate identity, reprices the route, and returns `authority: false` evidence.
 
-The complete Python → Rust subprocess path is exercised in CI against a real compiled verifier binary, including candidate-identity rejection and authority-boundary checks.
+Phase 2C-1 then generates deterministic alternate market states for reserve movement, cost changes, slippage, latency, and gas. Every state is hash-bound and sent through the same Rust verifier. The resulting receipt records survival rate, worst-case delta, median delta, failure reasons, and a declared robustness class. The included scenario values are teaching fixtures, not calibrated market probabilities.
+
+The complete Python → Rust subprocess and robustness paths are exercised in CI against a real compiled verifier binary, including candidate-identity rejection and authority-boundary checks.
 
 ```text
 QAOA discovers the geometry of the opportunity.
 Rust confirms that the geometry still exists.
+Perturbation tests whether that geometry survives pressure.
 Python controls what may happen with that knowledge.
 Human review remains the promotion gate.
 ```
@@ -134,13 +138,16 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | QAOA delta triangulation core | `eve_q/qaoa_delta.py` | Enumerates triangular price deltas, builds QUBO/Ising contracts, and provides a classical fallback with `authority: false`. |
 | QAOA sampling and confidence receipts | `eve_q/qaoa_sampling.py` | Performs bounded local sampling, deterministic decoding, and exact-baseline comparison. |
 | Python-to-Rust repricing bridge | `eve_q/rust_repricing.py` | Binds candidate evidence to a strict subprocess request and fails closed on protocol drift. |
+| Perturbed-state robustness engine | `eve_q/delta_robustness.py` | Reprices a selected candidate across deterministic alternate market states and emits non-authoritative survival evidence. |
 | Rust exact delta verifier | `rust/delta-verifier/` | Reprices a closed triangular route after fee, slippage, latency, gas, and margin assumptions without network access. |
 | Repricing request schema | `schemas/delta_repricing_request.schema.json` | Defines the strict hash-bound candidate request surface. |
 | Repricing response schema | `schemas/delta_repricing_response.schema.json` | Defines the strict exact-verification response surface. |
+| Robustness receipt schema | `schemas/delta_robustness_receipt.schema.json` | Defines scenario, survival, failure, and authority invariants for robustness evidence. |
 | Hybrid delta architecture | `docs/QAOA_DELTA_TRIANGULATION_v0_1.md` | Defines Python, Qiskit, Rust, fallback, and authority boundaries. |
 | Phase 2A architecture | `docs/QAOA_DELTA_PHASE_2A.md` | Defines bounded QAOA sampling and confidence receipts. |
 | Phase 2B architecture | `docs/QAOA_DELTA_PHASE_2B.md` | Defines the isolated Python-to-Rust exact-repricing contract. |
-| Hybrid delta CI | `.github/workflows/hybrid-delta-ci.yml` | Validates Python 3.11/3.13, Qiskit 2.5, stable Rust, and the real subprocess bridge. |
+| Phase 2C-1 architecture | `docs/QAOA_DELTA_PHASE_2C1.md` | Defines deterministic perturbed-state robustness evidence. |
+| Hybrid delta CI | `.github/workflows/hybrid-delta-ci.yml` | Validates Python 3.11/3.13, Qiskit 2.5, stable Rust, the real subprocess bridge, and robustness scenarios. |
 
 Membrane bridge:
 
@@ -152,7 +159,7 @@ Chain:
 
 Hybrid delta chain:
 
-`market snapshot -> triangular cycles -> QUBO -> QAOA confidence receipt -> Rust exact repricing -> policy review -> simulation receipt`
+`market snapshot -> triangular cycles -> QUBO -> QAOA confidence receipt -> Rust exact repricing -> perturbed-state robustness -> policy review -> simulation receipt`
 
 Current law:
 

--- a/docs/QAOA_DELTA_PHASE_2C1.md
+++ b/docs/QAOA_DELTA_PHASE_2C1.md
@@ -1,0 +1,84 @@
+# QAOA Delta Phase 2C-1 — Perturbed-State Robustness
+
+## Purpose
+
+A profitable point estimate is not yet a durable opportunity. Phase 2C-1 subjects one QAOA-selected, Rust-verified triangular candidate to a bounded family of alternate market states and records whether the verified margin survives.
+
+```text
+QAOA candidate
+→ exact Rust repricing
+→ deterministic perturbation family
+→ exact Rust repricing per state
+→ robustness receipt
+→ human review
+```
+
+## Perturbation surface
+
+Each scenario may alter, in candidate edge order:
+
+- quoted-rate basis points, representing reserve or price movement;
+- fee basis points;
+- slippage basis points;
+- latency-penalty basis points;
+- gas log penalty.
+
+Scenarios are sorted by stable identifier and limited to 256 states. Duplicate scenario identities are rejected. Every alternate state receives a derived SHA-256 snapshot identity binding the baseline snapshot, scenario parameters, perturbed edge values, candidate identity, and gas assumption.
+
+## Evidence
+
+A `delta-robustness-receipt-v0.1` records:
+
+- baseline snapshot hash;
+- QUBO model hash;
+- QAOA confidence-receipt identity;
+- candidate identity;
+- scenario-set hash;
+- scenario and survival counts;
+- survival rate;
+- worst-case and median verified log delta;
+- margin-failure reason counts;
+- deterministic robustness class;
+- every scenario-specific Rust request and result;
+- `authority: false` at every layer.
+
+## Classification
+
+| Survival rate | Class |
+| --- | --- |
+| 1.0 | `robust` |
+| at least 0.8 | `resilient` |
+| at least 0.5 | `conditional` |
+| greater than 0 | `fragile` |
+| 0 | `failed` |
+
+These labels summarize a declared scenario family. They do not imply calibrated market probabilities.
+
+## Standard teaching scenarios
+
+The repository includes deterministic baseline, reserve, slippage, latency, gas, and combined-adverse scenarios. Their values are examples for testing the architecture, not claims about realistic market distributions.
+
+Production research must source perturbation magnitudes from measured volatility, liquidity depth, quote age, gas distributions, and venue behavior, with provenance recorded separately.
+
+## Fail-closed rules
+
+The robustness lane rejects:
+
+- malformed or duplicate scenarios;
+- non-finite perturbations;
+- cost assumptions at or above 10,000 basis points;
+- missing candidate edges;
+- missing or relative Rust executable paths;
+- subprocess timeout, crash, or malformed output;
+- candidate, snapshot, model, or receipt identity drift;
+- any authority escalation.
+
+## Boundary
+
+This phase performs no wallet signing, transaction construction, RPC submission, borrowing, scheduling, mempool mutation, or capital movement.
+
+```text
+A route that survives perturbation earns stronger evidence.
+Stronger evidence still does not become authority.
+Human promotion remains sovereign.
+```

--- a/eve_q/delta_robustness.py
+++ b/eve_q/delta_robustness.py
@@ -1,0 +1,420 @@
+"""Deterministic perturbed-state robustness evidence for verified delta candidates.
+
+The module creates bounded alternate market states and routes each state through the
+isolated Rust exact repricer. It emits research evidence only. It cannot sign,
+submit, borrow, schedule, move capital, or grant authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from eve_q.qaoa_delta import MarketEdge, TriangularCycle
+from eve_q.qaoa_sampling import QaoaConfidenceReceipt
+from eve_q.rust_repricing import build_repricing_request, run_rust_repricing
+
+_BPS = 10_000.0
+_MAX_SCENARIOS = 256
+
+
+def _require_vector(values: tuple[float, float, float], field_name: str) -> None:
+    if len(values) != 3:
+        raise ValueError(f"{field_name} must contain exactly three values")
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError(f"{field_name} values must be finite")
+
+
+def _require_sha256(value: str, field_name: str) -> None:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{field_name} must be 64 lowercase hexadecimal characters")
+
+
+@dataclass(frozen=True)
+class PerturbationScenario:
+    """One bounded alternate state aligned to the candidate's three-edge order."""
+
+    scenario_id: str
+    rate_shift_bps: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    fee_shift_bps: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    slippage_shift_bps: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    latency_shift_bps: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    gas_penalty_log_shift: float = 0.0
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.scenario_id.startswith("delta-scenario:"):
+            raise ValueError("scenario_id must use the delta-scenario namespace")
+        for field_name, values in (
+            ("rate_shift_bps", self.rate_shift_bps),
+            ("fee_shift_bps", self.fee_shift_bps),
+            ("slippage_shift_bps", self.slippage_shift_bps),
+            ("latency_shift_bps", self.latency_shift_bps),
+        ):
+            _require_vector(values, field_name)
+        if any(not -5_000.0 <= value <= 5_000.0 for value in self.rate_shift_bps):
+            raise ValueError("rate_shift_bps values must remain in [-5000, 5000]")
+        for field_name, values in (
+            ("fee_shift_bps", self.fee_shift_bps),
+            ("slippage_shift_bps", self.slippage_shift_bps),
+            ("latency_shift_bps", self.latency_shift_bps),
+        ):
+            if any(not 0.0 <= value <= 5_000.0 for value in values):
+                raise ValueError(f"{field_name} values must remain in [0, 5000]")
+        if not math.isfinite(self.gas_penalty_log_shift) or self.gas_penalty_log_shift < 0.0:
+            raise ValueError("gas_penalty_log_shift must be finite and non-negative")
+        if self.authority:
+            raise ValueError("perturbation scenarios cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "scenario_id": self.scenario_id,
+            "rate_shift_bps": list(self.rate_shift_bps),
+            "fee_shift_bps": list(self.fee_shift_bps),
+            "slippage_shift_bps": list(self.slippage_shift_bps),
+            "latency_shift_bps": list(self.latency_shift_bps),
+            "gas_penalty_log_shift": self.gas_penalty_log_shift,
+            "authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class ScenarioRobustnessResult:
+    scenario: PerturbationScenario
+    scenario_snapshot_sha256: str
+    request_id: str
+    net_log_delta: float
+    minimum_log_delta: float
+    profitable: bool
+    passes_margin: bool
+    delta_drift: float
+    failure_reasons: tuple[str, ...]
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        _require_sha256(self.scenario_snapshot_sha256, "scenario_snapshot_sha256")
+        if not self.request_id.startswith("delta-reprice:"):
+            raise ValueError("request_id must use the delta-reprice namespace")
+        for field_name, value in (
+            ("net_log_delta", self.net_log_delta),
+            ("minimum_log_delta", self.minimum_log_delta),
+            ("delta_drift", self.delta_drift),
+        ):
+            if not math.isfinite(value):
+                raise ValueError(f"{field_name} must be finite")
+        expected_reasons: list[str] = []
+        if not self.profitable:
+            expected_reasons.append("not_profitable")
+        if not self.passes_margin:
+            expected_reasons.append("below_minimum_margin")
+        if self.failure_reasons != tuple(expected_reasons):
+            raise ValueError("failure_reasons must match the verification outcome")
+        if self.authority:
+            raise ValueError("scenario results cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "scenario": self.scenario.as_dict(),
+            "scenario_snapshot_sha256": self.scenario_snapshot_sha256,
+            "request_id": self.request_id,
+            "net_log_delta": self.net_log_delta,
+            "minimum_log_delta": self.minimum_log_delta,
+            "profitable": self.profitable,
+            "passes_margin": self.passes_margin,
+            "delta_drift": self.delta_drift,
+            "failure_reasons": list(self.failure_reasons),
+            "authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class DeltaRobustnessReceipt:
+    receipt_id: str
+    baseline_snapshot_sha256: str
+    model_sha256: str
+    confidence_receipt_id: str
+    candidate_id: str
+    scenario_set_sha256: str
+    scenario_count: int
+    survival_count: int
+    survival_rate: float
+    worst_case_log_delta: float
+    median_log_delta: float
+    margin_failure_reasons: Mapping[str, int]
+    robustness_class: str
+    results: tuple[ScenarioRobustnessResult, ...]
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.receipt_id.startswith("delta-robustness:"):
+            raise ValueError("receipt_id must use the delta-robustness namespace")
+        _require_sha256(self.baseline_snapshot_sha256, "baseline_snapshot_sha256")
+        _require_sha256(self.model_sha256, "model_sha256")
+        _require_sha256(self.scenario_set_sha256, "scenario_set_sha256")
+        if not self.confidence_receipt_id.startswith("qaoa-confidence:"):
+            raise ValueError("confidence_receipt_id must use the qaoa-confidence namespace")
+        if not self.candidate_id.startswith("triangle:"):
+            raise ValueError("candidate_id must use the triangle namespace")
+        if self.scenario_count != len(self.results) or self.scenario_count < 1:
+            raise ValueError("scenario_count must match a non-empty result set")
+        if self.survival_count != sum(result.passes_margin for result in self.results):
+            raise ValueError("survival_count must match the scenario results")
+        expected_rate = self.survival_count / self.scenario_count
+        if not math.isclose(self.survival_rate, expected_rate, abs_tol=1e-15):
+            raise ValueError("survival_rate must match survival_count / scenario_count")
+        if not all(
+            math.isfinite(value)
+            for value in (self.survival_rate, self.worst_case_log_delta, self.median_log_delta)
+        ):
+            raise ValueError("robustness summary values must be finite")
+        if self.robustness_class not in {"robust", "resilient", "conditional", "fragile", "failed"}:
+            raise ValueError("robustness_class is invalid")
+        if self.authority:
+            raise ValueError("robustness receipts cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": "delta-robustness-receipt-v0.1",
+            "receipt_id": self.receipt_id,
+            "baseline_snapshot_sha256": self.baseline_snapshot_sha256,
+            "model_sha256": self.model_sha256,
+            "confidence_receipt_id": self.confidence_receipt_id,
+            "candidate_id": self.candidate_id,
+            "scenario_set_sha256": self.scenario_set_sha256,
+            "scenario_count": self.scenario_count,
+            "survival_count": self.survival_count,
+            "survival_rate": self.survival_rate,
+            "worst_case_log_delta": self.worst_case_log_delta,
+            "median_log_delta": self.median_log_delta,
+            "margin_failure_reasons": dict(sorted(self.margin_failure_reasons.items())),
+            "robustness_class": self.robustness_class,
+            "results": [result.as_dict() for result in self.results],
+            "authority": False,
+        }
+
+
+def standard_adverse_scenarios() -> tuple[PerturbationScenario, ...]:
+    """Return deterministic teaching scenarios; values are not market calibration."""
+
+    return (
+        PerturbationScenario("delta-scenario:baseline"),
+        PerturbationScenario("delta-scenario:reserve-soft", rate_shift_bps=(-5.0, -5.0, -5.0)),
+        PerturbationScenario("delta-scenario:reserve-hard", rate_shift_bps=(-15.0, -15.0, -15.0)),
+        PerturbationScenario("delta-scenario:slippage-spike", slippage_shift_bps=(10.0, 10.0, 10.0)),
+        PerturbationScenario("delta-scenario:latency-spike", latency_shift_bps=(5.0, 5.0, 5.0)),
+        PerturbationScenario("delta-scenario:gas-spike", gas_penalty_log_shift=0.005),
+        PerturbationScenario(
+            "delta-scenario:combined-adverse",
+            rate_shift_bps=(-10.0, -10.0, -10.0),
+            fee_shift_bps=(2.0, 2.0, 2.0),
+            slippage_shift_bps=(8.0, 8.0, 8.0),
+            latency_shift_bps=(4.0, 4.0, 4.0),
+            gas_penalty_log_shift=0.003,
+        ),
+    )
+
+
+def _apply_scenario(
+    candidate: TriangularCycle,
+    market_edges: Sequence[MarketEdge],
+    scenario: PerturbationScenario,
+) -> tuple[tuple[MarketEdge, MarketEdge, MarketEdge], TriangularCycle]:
+    edges_by_id = {edge.edge_id: edge for edge in market_edges}
+    if len(edges_by_id) != len(market_edges):
+        raise ValueError("market edge identifiers must be unique")
+    try:
+        ordered = tuple(edges_by_id[edge_id] for edge_id in candidate.edge_ids)
+    except KeyError as exc:
+        raise ValueError(f"candidate references missing market edge {exc.args[0]!r}") from exc
+
+    perturbed: list[MarketEdge] = []
+    for index, edge in enumerate(ordered):
+        quoted_rate = edge.quoted_rate * (1.0 + scenario.rate_shift_bps[index] / _BPS)
+        fee_bps = edge.fee_bps + scenario.fee_shift_bps[index]
+        slippage_bps = edge.slippage_bps + scenario.slippage_shift_bps[index]
+        latency_bps = edge.latency_penalty_bps + scenario.latency_shift_bps[index]
+        if quoted_rate <= 0.0:
+            raise ValueError("scenario produced a non-positive quoted rate")
+        if any(value >= _BPS for value in (fee_bps, slippage_bps, latency_bps)):
+            raise ValueError("scenario produced a cost assumption at or above 10000 bps")
+        perturbed.append(
+            MarketEdge(
+                edge_id=edge.edge_id,
+                source_asset=edge.source_asset,
+                target_asset=edge.target_asset,
+                quoted_rate=quoted_rate,
+                fee_bps=fee_bps,
+                slippage_bps=slippage_bps,
+                latency_penalty_bps=latency_bps,
+                venue=edge.venue,
+            )
+        )
+
+    gas_penalty = candidate.gas_penalty_log + scenario.gas_penalty_log_shift
+    net_multiplier = math.prod(edge.effective_rate for edge in perturbed)
+    net_log_delta = math.log(net_multiplier) - gas_penalty
+    perturbed_candidate = TriangularCycle(
+        candidate_id=candidate.candidate_id,
+        edge_ids=candidate.edge_ids,
+        asset_path=candidate.asset_path,
+        net_multiplier=net_multiplier,
+        net_log_delta=net_log_delta,
+        gas_penalty_log=gas_penalty,
+    )
+    return (perturbed[0], perturbed[1], perturbed[2]), perturbed_candidate
+
+
+def _scenario_snapshot_sha256(
+    baseline_snapshot_sha256: str,
+    scenario: PerturbationScenario,
+    edges: Sequence[MarketEdge],
+    candidate: TriangularCycle,
+) -> str:
+    payload = {
+        "baseline_snapshot_sha256": baseline_snapshot_sha256,
+        "scenario": scenario.as_dict(),
+        "candidate_id": candidate.candidate_id,
+        "gas_penalty_log": candidate.gas_penalty_log,
+        "edges": [
+            {
+                "edge_id": edge.edge_id,
+                "quoted_rate": edge.quoted_rate,
+                "fee_bps": edge.fee_bps,
+                "slippage_bps": edge.slippage_bps,
+                "latency_penalty_bps": edge.latency_penalty_bps,
+            }
+            for edge in edges
+        ],
+        "authority": False,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _classify(survival_rate: float) -> str:
+    if math.isclose(survival_rate, 1.0, abs_tol=1e-15):
+        return "robust"
+    if survival_rate >= 0.8:
+        return "resilient"
+    if survival_rate >= 0.5:
+        return "conditional"
+    if survival_rate > 0.0:
+        return "fragile"
+    return "failed"
+
+
+def evaluate_candidate_robustness(
+    receipt: QaoaConfidenceReceipt,
+    candidate: TriangularCycle,
+    market_edges: Sequence[MarketEdge],
+    scenarios: Sequence[PerturbationScenario],
+    *,
+    baseline_snapshot_sha256: str,
+    minimum_log_delta: float,
+    executable: str | Path,
+    timeout_seconds: float = 2.0,
+) -> DeltaRobustnessReceipt:
+    """Reprice a selected candidate across deterministic alternate states."""
+
+    _require_sha256(baseline_snapshot_sha256, "baseline_snapshot_sha256")
+    if not scenarios:
+        raise ValueError("at least one perturbation scenario is required")
+    if len(scenarios) > _MAX_SCENARIOS:
+        raise ValueError(f"scenario count exceeds the {_MAX_SCENARIOS}-scenario limit")
+    scenario_ids = [scenario.scenario_id for scenario in scenarios]
+    if len(set(scenario_ids)) != len(scenario_ids):
+        raise ValueError("scenario identifiers must be unique")
+    ordered_scenarios = tuple(sorted(scenarios, key=lambda item: item.scenario_id))
+
+    results: list[ScenarioRobustnessResult] = []
+    reason_counts: dict[str, int] = {}
+    for scenario in ordered_scenarios:
+        perturbed_edges, perturbed_candidate = _apply_scenario(candidate, market_edges, scenario)
+        scenario_snapshot = _scenario_snapshot_sha256(
+            baseline_snapshot_sha256,
+            scenario,
+            perturbed_edges,
+            perturbed_candidate,
+        )
+        request = build_repricing_request(
+            receipt,
+            perturbed_candidate,
+            perturbed_edges,
+            snapshot_sha256=scenario_snapshot,
+            minimum_log_delta=minimum_log_delta,
+        )
+        evidence = run_rust_repricing(
+            request,
+            perturbed_candidate,
+            executable=executable,
+            timeout_seconds=timeout_seconds,
+        )
+        reasons: list[str] = []
+        if not evidence.profitable:
+            reasons.append("not_profitable")
+        if not evidence.passes_margin:
+            reasons.append("below_minimum_margin")
+        for reason in reasons:
+            reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        results.append(
+            ScenarioRobustnessResult(
+                scenario=scenario,
+                scenario_snapshot_sha256=scenario_snapshot,
+                request_id=evidence.request_id,
+                net_log_delta=evidence.net_log_delta,
+                minimum_log_delta=evidence.minimum_log_delta,
+                profitable=evidence.profitable,
+                passes_margin=evidence.passes_margin,
+                delta_drift=evidence.delta_drift,
+                failure_reasons=tuple(reasons),
+            )
+        )
+
+    survival_count = sum(result.passes_margin for result in results)
+    survival_rate = survival_count / len(results)
+    deltas = [result.net_log_delta for result in results]
+    scenario_set_payload = [scenario.as_dict() for scenario in ordered_scenarios]
+    scenario_set_sha256 = hashlib.sha256(
+        json.dumps(
+            scenario_set_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+    receipt_seed = {
+        "baseline_snapshot_sha256": baseline_snapshot_sha256,
+        "model_sha256": receipt.model_sha256,
+        "confidence_receipt_id": receipt.receipt_id,
+        "candidate_id": candidate.candidate_id,
+        "scenario_set_sha256": scenario_set_sha256,
+        "results": [result.as_dict() for result in results],
+        "authority": False,
+    }
+    receipt_hash = hashlib.sha256(
+        json.dumps(receipt_seed, sort_keys=True, separators=(",", ":"), allow_nan=False).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+
+    return DeltaRobustnessReceipt(
+        receipt_id=f"delta-robustness:{receipt_hash[:24]}",
+        baseline_snapshot_sha256=baseline_snapshot_sha256,
+        model_sha256=receipt.model_sha256,
+        confidence_receipt_id=receipt.receipt_id,
+        candidate_id=candidate.candidate_id,
+        scenario_set_sha256=scenario_set_sha256,
+        scenario_count=len(results),
+        survival_count=survival_count,
+        survival_rate=survival_rate,
+        worst_case_log_delta=min(deltas),
+        median_log_delta=statistics.median(deltas),
+        margin_failure_reasons=reason_counts,
+        robustness_class=_classify(survival_rate),
+        results=tuple(results),
+    )

--- a/schemas/delta_robustness_receipt.schema.json
+++ b/schemas/delta_robustness_receipt.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://spiralbloom.local/schemas/delta_robustness_receipt.schema.json",
+  "title": "Delta Robustness Receipt v0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "baseline_snapshot_sha256",
+    "model_sha256",
+    "confidence_receipt_id",
+    "candidate_id",
+    "scenario_set_sha256",
+    "scenario_count",
+    "survival_count",
+    "survival_rate",
+    "worst_case_log_delta",
+    "median_log_delta",
+    "margin_failure_reasons",
+    "robustness_class",
+    "results",
+    "authority"
+  ],
+  "properties": {
+    "schema_version": {"const": "delta-robustness-receipt-v0.1"},
+    "receipt_id": {"type": "string", "pattern": "^delta-robustness:[0-9a-f]{24}$"},
+    "baseline_snapshot_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "model_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "confidence_receipt_id": {"type": "string", "pattern": "^qaoa-confidence:"},
+    "candidate_id": {"type": "string", "pattern": "^triangle:"},
+    "scenario_set_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "scenario_count": {"type": "integer", "minimum": 1, "maximum": 256},
+    "survival_count": {"type": "integer", "minimum": 0},
+    "survival_rate": {"type": "number", "minimum": 0, "maximum": 1},
+    "worst_case_log_delta": {"type": "number"},
+    "median_log_delta": {"type": "number"},
+    "margin_failure_reasons": {
+      "type": "object",
+      "additionalProperties": {"type": "integer", "minimum": 1}
+    },
+    "robustness_class": {
+      "enum": ["robust", "resilient", "conditional", "fragile", "failed"]
+    },
+    "results": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 256,
+      "items": {"$ref": "#/$defs/result"}
+    },
+    "authority": {"const": false}
+  },
+  "$defs": {
+    "triple": {
+      "type": "array",
+      "prefixItems": [{"type": "number"}, {"type": "number"}, {"type": "number"}],
+      "items": false
+    },
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenario_id",
+        "rate_shift_bps",
+        "fee_shift_bps",
+        "slippage_shift_bps",
+        "latency_shift_bps",
+        "gas_penalty_log_shift",
+        "authority"
+      ],
+      "properties": {
+        "scenario_id": {"type": "string", "pattern": "^delta-scenario:"},
+        "rate_shift_bps": {"$ref": "#/$defs/triple"},
+        "fee_shift_bps": {"$ref": "#/$defs/triple"},
+        "slippage_shift_bps": {"$ref": "#/$defs/triple"},
+        "latency_shift_bps": {"$ref": "#/$defs/triple"},
+        "gas_penalty_log_shift": {"type": "number", "minimum": 0},
+        "authority": {"const": false}
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenario",
+        "scenario_snapshot_sha256",
+        "request_id",
+        "net_log_delta",
+        "minimum_log_delta",
+        "profitable",
+        "passes_margin",
+        "delta_drift",
+        "failure_reasons",
+        "authority"
+      ],
+      "properties": {
+        "scenario": {"$ref": "#/$defs/scenario"},
+        "scenario_snapshot_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "request_id": {"type": "string", "pattern": "^delta-reprice:"},
+        "net_log_delta": {"type": "number"},
+        "minimum_log_delta": {"type": "number"},
+        "profitable": {"type": "boolean"},
+        "passes_margin": {"type": "boolean"},
+        "delta_drift": {"type": "number"},
+        "failure_reasons": {
+          "type": "array",
+          "items": {"enum": ["not_profitable", "below_minimum_margin"]},
+          "uniqueItems": true
+        },
+        "authority": {"const": false}
+      }
+    }
+  }
+}

--- a/tests/test_delta_robustness.py
+++ b/tests/test_delta_robustness.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from eve_q.delta_robustness import (
+    PerturbationScenario,
+    _apply_scenario,
+    evaluate_candidate_robustness,
+    standard_adverse_scenarios,
+)
+from eve_q.qaoa_delta import (
+    MarketEdge,
+    build_cycle_selection_qubo,
+    enumerate_triangular_cycles,
+)
+from eve_q.qaoa_sampling import build_qaoa_confidence_receipt
+
+
+def _fixture():
+    edges = (
+        MarketEdge("usd-eth", "USD", "ETH", 0.0005, venue="alpha"),
+        MarketEdge("eth-btc", "ETH", "BTC", 0.05, venue="beta"),
+        MarketEdge("btc-usd", "BTC", "USD", 41_000.0, venue="gamma"),
+    )
+    candidate = enumerate_triangular_cycles(edges)[0]
+    model = build_cycle_selection_qubo((candidate,))
+    receipt = build_qaoa_confidence_receipt(
+        model,
+        (candidate,),
+        {"1": 1.0},
+        solver="test-distribution",
+        reps=1,
+    )
+    return edges, candidate, receipt
+
+
+def test_standard_scenarios_are_deterministic_and_non_authoritative() -> None:
+    first = standard_adverse_scenarios()
+    second = standard_adverse_scenarios()
+
+    assert first == second
+    assert len(first) == 7
+    assert len({scenario.scenario_id for scenario in first}) == 7
+    assert all(scenario.authority is False for scenario in first)
+
+
+def test_adverse_scenario_reduces_candidate_delta() -> None:
+    edges, candidate, _ = _fixture()
+    scenario = PerturbationScenario(
+        "delta-scenario:adverse-test",
+        rate_shift_bps=(-10.0, -10.0, -10.0),
+        slippage_shift_bps=(5.0, 5.0, 5.0),
+        latency_shift_bps=(2.0, 2.0, 2.0),
+        gas_penalty_log_shift=0.002,
+    )
+
+    perturbed_edges, perturbed_candidate = _apply_scenario(candidate, edges, scenario)
+
+    assert perturbed_candidate.candidate_id == candidate.candidate_id
+    assert perturbed_candidate.net_log_delta < candidate.net_log_delta
+    assert all(edge.authority is False for edge in perturbed_edges)
+    assert perturbed_candidate.authority is False
+
+
+def test_rejects_duplicate_scenario_identity_before_execution() -> None:
+    edges, candidate, receipt = _fixture()
+    duplicate = PerturbationScenario("delta-scenario:duplicate")
+
+    with pytest.raises(ValueError, match="identifiers must be unique"):
+        evaluate_candidate_robustness(
+            receipt,
+            candidate,
+            edges,
+            (duplicate, duplicate),
+            baseline_snapshot_sha256="d" * 64,
+            minimum_log_delta=0.01,
+            executable="/not/reached",
+        )
+
+
+def test_rejects_authority_escalation() -> None:
+    with pytest.raises(ValueError, match="cannot grant authority"):
+        PerturbationScenario("delta-scenario:forbidden", authority=True)
+
+
+def test_real_rust_subprocess_builds_deterministic_robustness_receipt() -> None:
+    binary = os.environ.get("CODEX_DELTA_VERIFIER_BIN")
+    if not binary:
+        pytest.skip("Rust verifier binary not provided")
+
+    edges, candidate, receipt = _fixture()
+    scenarios = (
+        PerturbationScenario("delta-scenario:baseline"),
+        PerturbationScenario(
+            "delta-scenario:collapse",
+            rate_shift_bps=(-100.0, -100.0, -100.0),
+            slippage_shift_bps=(25.0, 25.0, 25.0),
+            latency_shift_bps=(10.0, 10.0, 10.0),
+            gas_penalty_log_shift=0.02,
+        ),
+    )
+    kwargs = {
+        "baseline_snapshot_sha256": "d" * 64,
+        "minimum_log_delta": 0.01,
+        "executable": Path(binary).resolve(),
+    }
+
+    first = evaluate_candidate_robustness(receipt, candidate, edges, scenarios, **kwargs)
+    second = evaluate_candidate_robustness(receipt, candidate, edges, scenarios, **kwargs)
+
+    assert first == second
+    assert first.scenario_count == 2
+    assert first.survival_count == 1
+    assert first.survival_rate == pytest.approx(0.5)
+    assert first.robustness_class == "conditional"
+    assert first.worst_case_log_delta < first.median_log_delta
+    assert first.margin_failure_reasons["below_minimum_margin"] == 1
+    assert first.results[0].scenario.scenario_id == "delta-scenario:baseline"
+    assert first.results[1].scenario.scenario_id == "delta-scenario:collapse"
+    assert all(abs(result.delta_drift) < 1e-12 for result in first.results)
+    assert first.authority is False


### PR DESCRIPTION
## Summary

Implements Phase 2C-1 of the hybrid delta engine: deterministic perturbed-state robustness analysis for QAOA-selected, Rust-verified triangular candidates.

## Included

- bounded perturbation scenarios for rate, fee, slippage, latency, and gas changes
- deterministic scenario ordering and duplicate identity rejection
- derived SHA-256 identity for every alternate market state
- exact Rust repricing for every scenario through the existing isolated subprocess membrane
- survival count and survival rate
- worst-case and median verified log delta
- margin-failure reason accounting
- deterministic robustness classes
- strict `delta-robustness-receipt-v0.1` schema
- Python and real Rust subprocess tests
- expanded hybrid CI and canonical README surface

## GitHub validation

All dedicated gates passed on the current head:

- Python 3.11 hybrid core: PASS
- Python 3.13 hybrid core: PASS
- robustness schema syntax: PASS
- Qiskit 2.5 local sampling: PASS
- Rust exact verifier: PASS
- real Python → compiled Rust robustness scenarios: PASS
- duplicate scenario and authority-escalation rejection: PASS

## Design law

```text
A point estimate is a proposal.
Rust establishes exact arithmetic.
Perturbation tests whether the opportunity survives pressure.
Stronger evidence still cannot grant authority.
```

## Boundaries

- simulation and research only
- no wallet or transaction signing
- no RPC submission
- no flash-loan borrowing
- no mempool mutation
- no scheduler authority
- no autonomous capital movement
- all scenarios, results, and receipts retain `authority: false`

## Scope

The included perturbation magnitudes are deterministic teaching fixtures, not calibrated market probabilities. Market-derived scenario calibration and flash-liquidity provider/amount variables remain later bounded phases tracked by issue #48.

## Human gate

The branch is validated and ready for review. No live execution authority is introduced.