### PR TITLE
Add source-bound market perturbation calibration

### DIFF
--- a/.github/workflows/hybrid-delta-ci.yml
+++ b/.github/workflows/hybrid-delta-ci.yml
@@ -9,22 +9,26 @@ on:
       - "eve_q/rust_repricing.py"
       - "eve_q/delta_robustness.py"
       - "eve_q/flash_liquidity.py"
+      - "eve_q/perturbation_calibration.py"
       - "tests/test_qaoa_delta.py"
       - "tests/test_qaoa_sampling.py"
       - "tests/test_rust_repricing.py"
       - "tests/test_delta_robustness.py"
       - "tests/test_flash_liquidity.py"
+      - "tests/test_perturbation_calibration.py"
       - "rust/delta-verifier/**"
       - "schemas/delta_repricing_request.schema.json"
       - "schemas/delta_repricing_response.schema.json"
       - "schemas/delta_robustness_receipt.schema.json"
       - "schemas/flash_liquidity_request.schema.json"
       - "schemas/flash_liquidity_response.schema.json"
+      - "schemas/perturbation_calibration_receipt.schema.json"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
       - "docs/QAOA_DELTA_PHASE_2B.md"
       - "docs/QAOA_DELTA_PHASE_2C1.md"
       - "docs/QAOA_DELTA_PHASE_2C2.md"
+      - "docs/QAOA_DELTA_PHASE_2D.md"
       - "pyproject.toml"
       - ".github/workflows/hybrid-delta-ci.yml"
   push:
@@ -37,22 +41,26 @@ on:
       - "eve_q/rust_repricing.py"
       - "eve_q/delta_robustness.py"
       - "eve_q/flash_liquidity.py"
+      - "eve_q/perturbation_calibration.py"
       - "tests/test_qaoa_delta.py"
       - "tests/test_qaoa_sampling.py"
       - "tests/test_rust_repricing.py"
       - "tests/test_delta_robustness.py"
       - "tests/test_flash_liquidity.py"
+      - "tests/test_perturbation_calibration.py"
       - "rust/delta-verifier/**"
       - "schemas/delta_repricing_request.schema.json"
       - "schemas/delta_repricing_response.schema.json"
       - "schemas/delta_robustness_receipt.schema.json"
       - "schemas/flash_liquidity_request.schema.json"
       - "schemas/flash_liquidity_response.schema.json"
+      - "schemas/perturbation_calibration_receipt.schema.json"
       - "docs/QAOA_DELTA_TRIANGULATION_v0_1.md"
       - "docs/QAOA_DELTA_PHASE_2A.md"
       - "docs/QAOA_DELTA_PHASE_2B.md"
       - "docs/QAOA_DELTA_PHASE_2C1.md"
       - "docs/QAOA_DELTA_PHASE_2C2.md"
+      - "docs/QAOA_DELTA_PHASE_2D.md"
       - "pyproject.toml"
       - ".github/workflows/hybrid-delta-ci.yml"
 
@@ -85,13 +93,15 @@ jobs:
             eve_q/qaoa_sampling.py \
             eve_q/rust_repricing.py \
             eve_q/delta_robustness.py \
-            eve_q/flash_liquidity.py
+            eve_q/flash_liquidity.py \
+            eve_q/perturbation_calibration.py
 
       - name: Validate evidence schema syntax
         run: |
           python -m json.tool schemas/delta_robustness_receipt.schema.json >/dev/null
           python -m json.tool schemas/flash_liquidity_request.schema.json >/dev/null
           python -m json.tool schemas/flash_liquidity_response.schema.json >/dev/null
+          python -m json.tool schemas/perturbation_calibration_receipt.schema.json >/dev/null
 
       - name: Run hybrid delta tests
         run: |
@@ -101,6 +111,7 @@ jobs:
             tests/test_rust_repricing.py \
             tests/test_delta_robustness.py \
             tests/test_flash_liquidity.py \
+            tests/test_perturbation_calibration.py \
             --no-cov -q
 
   qiskit-adapter:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ CodexTradingEngine may produce:
 - perturbed-state robustness receipts
 - flash-liquidity geometry candidates
 - Rust flash-liquidity verification evidence
+- source-bound perturbation calibration receipts
 
 These outputs are review artifacts. They are not commands.
 
@@ -99,15 +100,18 @@ Classical solvers remain available for fallback, benchmarking, and independent c
 
 The implementation is intentionally simulation-only. Qiskit performs bounded local sampling and emits confidence evidence. Python binds that evidence to a strict request and invokes an explicit local Rust verifier with `shell=False`. Rust independently reconstructs candidate identity, reprices the route, and returns `authority: false` evidence.
 
-Phase 2C-1 then generates deterministic alternate market states for reserve movement, cost changes, slippage, latency, and gas. Every state is hash-bound and sent through the same Rust verifier. The resulting receipt records survival rate, worst-case delta, median delta, failure reasons, and a declared robustness class. The included scenario values are teaching fixtures, not calibrated market probabilities.
+Phase 2C-1 generates deterministic alternate market states for reserve movement, cost changes, slippage, latency, and gas. Every state is hash-bound and sent through the same Rust verifier. The resulting receipt records survival rate, worst-case delta, median delta, failure reasons, and a declared robustness class. The original included scenario values remain teaching fixtures rather than calibrated probabilities.
 
 Phase 2C-2 expands a route into provider, borrowed-asset, and amount-bucket geometry. QAOA may rank complete route-plus-liquidity candidates. A second isolated Rust binary reconstructs the triangular route, verifies declared capacity, calculates provider repayment, and determines whether the complete loop can repay itself above a declared minimum-profit threshold. No borrowing or transaction submission occurs.
 
-The complete Python → Rust subprocess, robustness, and flash-liquidity paths are exercised in CI against real compiled verifier binaries, including candidate-identity rejection and authority-boundary checks.
+Phase 2D accepts source-bound historical observations and deterministically calibrates adverse rate, fee, slippage, latency, and gas scenarios. Observations are aligned by edge identity, quantiles and clipping limits are explicit policy, and the emitted receipt binds the complete corpus, policy, and scenario set with SHA-256. The scenarios describe the supplied corpus; they do not promise recurrence or authorize execution.
+
+The complete Python → Rust subprocess, robustness, and flash-liquidity paths are exercised in CI against real compiled verifier binaries, including candidate-identity rejection and authority-boundary checks. The calibration path is independently exercised on Python 3.11 and 3.13.
 
 ```text
 QAOA discovers the geometry of the opportunity.
 Rust confirms that the geometry still exists.
+History calibrates the pressure test.
 Perturbation tests whether that geometry survives pressure.
 Flash-liquidity verification tests whether temporary capital can be repaid.
 Python controls what may happen with that knowledge.
@@ -144,12 +148,14 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | QAOA sampling and confidence receipts | `eve_q/qaoa_sampling.py` | Performs bounded local sampling, deterministic decoding, and exact-baseline comparison. |
 | Python-to-Rust repricing bridge | `eve_q/rust_repricing.py` | Binds candidate evidence to a strict subprocess request and fails closed on protocol drift. |
 | Perturbed-state robustness engine | `eve_q/delta_robustness.py` | Reprices a selected candidate across deterministic alternate market states and emits non-authoritative survival evidence. |
+| Market perturbation calibrator | `eve_q/perturbation_calibration.py` | Converts source-bound historical route observations into bounded empirical adverse scenarios and a non-authoritative calibration receipt. |
 | Flash-liquidity geometry | `eve_q/flash_liquidity.py` | Expands routes into provider and amount-bucket choices, builds the combined QUBO, and validates Rust evidence. |
 | Rust exact delta verifier | `rust/delta-verifier/` | Reprices a closed triangular route after fee, slippage, latency, gas, and margin assumptions without network access. |
 | Rust flash-liquidity verifier | `rust/delta-verifier/src/bin/codex-flash-liquidity-verifier.rs` | Verifies route identity, capacity, provider repayment, and minimum net profit without borrowing or network access. |
 | Repricing request schema | `schemas/delta_repricing_request.schema.json` | Defines the strict hash-bound candidate request surface. |
 | Repricing response schema | `schemas/delta_repricing_response.schema.json` | Defines the strict exact-verification response surface. |
 | Robustness receipt schema | `schemas/delta_robustness_receipt.schema.json` | Defines scenario, survival, failure, and authority invariants for robustness evidence. |
+| Perturbation calibration receipt schema | `schemas/perturbation_calibration_receipt.schema.json` | Defines corpus, policy, scenario, clipping, and authority invariants for empirical calibration evidence. |
 | Flash-liquidity request schema | `schemas/flash_liquidity_request.schema.json` | Defines the route, provider, bucket, capacity, and repayment request surface. |
 | Flash-liquidity response schema | `schemas/flash_liquidity_response.schema.json` | Defines exact capacity and repayment verification evidence. |
 | Hybrid delta architecture | `docs/QAOA_DELTA_TRIANGULATION_v0_1.md` | Defines Python, Qiskit, Rust, fallback, and authority boundaries. |
@@ -157,7 +163,8 @@ CodexTradingEngine is simulation-first and safety-gated. These surfaces define t
 | Phase 2B architecture | `docs/QAOA_DELTA_PHASE_2B.md` | Defines the isolated Python-to-Rust exact-repricing contract. |
 | Phase 2C-1 architecture | `docs/QAOA_DELTA_PHASE_2C1.md` | Defines deterministic perturbed-state robustness evidence. |
 | Phase 2C-2 architecture | `docs/QAOA_DELTA_PHASE_2C2.md` | Defines route-plus-provider-plus-amount geometry and repayment verification. |
-| Hybrid delta CI | `.github/workflows/hybrid-delta-ci.yml` | Validates Python 3.11/3.13, Qiskit 2.5, stable Rust, exact repricing, robustness, and flash-liquidity verification. |
+| Phase 2D architecture | `docs/QAOA_DELTA_PHASE_2D.md` | Defines source-bound historical observation calibration and empirical interpretation boundaries. |
+| Hybrid delta CI | `.github/workflows/hybrid-delta-ci.yml` | Validates Python 3.11/3.13, Qiskit 2.5, stable Rust, exact repricing, robustness, calibration, and flash-liquidity verification. |
 
 Membrane bridge:
 
@@ -169,7 +176,7 @@ Chain:
 
 Hybrid delta chain:
 
-`market snapshot -> triangular cycles -> route QUBO -> QAOA route receipt -> Rust exact repricing -> perturbed-state robustness -> route/provider/bucket QUBO -> QAOA liquidity receipt -> Rust capacity and repayment verification -> policy review -> simulation receipt`
+`market snapshot -> triangular cycles -> route QUBO -> QAOA route receipt -> Rust exact repricing -> source-bound historical corpus -> perturbation calibration -> Rust-backed robustness -> route/provider/bucket QUBO -> QAOA liquidity receipt -> Rust capacity and repayment verification -> policy review -> simulation receipt`
 
 Current law:
 

--- a/docs/QAOA_DELTA_PHASE_2D.md
+++ b/docs/QAOA_DELTA_PHASE_2D.md
@@ -1,0 +1,89 @@
+# QAOA Delta Phase 2D — Market-Derived Perturbation Calibration
+
+## Purpose
+
+Phase 2C-1 proved that a selected triangular candidate can be re-priced across deterministic alternate market states. Phase 2D replaces hand-authored teaching magnitudes with deterministic, source-bound perturbation scenarios derived from historical observations supplied to the engine.
+
+This remains an offline research surface. It does not discover providers, query venues, subscribe to feeds, sign transactions, borrow capital, schedule work, or submit RPC calls.
+
+## Input contract
+
+Each historical observation contains:
+
+- a stable `market-observation:*` identity;
+- a non-empty observation time label;
+- exactly three edge observations with stable edge identities;
+- quoted rate, fee, slippage, and latency assumptions for each edge;
+- a gas-log penalty;
+- a source SHA-256 binding the observation to its upstream artifact;
+- `authority: false`.
+
+The calibrator aligns observations by edge identity rather than tuple position. Candidate rotation, venue naming, and source ordering therefore cannot silently remap the route.
+
+## Calibration method
+
+For each route edge, the engine derives empirical adverse series relative to the declared baseline:
+
+```text
+rate adverse magnitude = max(0, -(observed_rate / baseline_rate - 1) * 10_000)
+fee increase           = max(0, observed_fee - baseline_fee)
+slippage increase      = max(0, observed_slippage - baseline_slippage)
+latency increase       = max(0, observed_latency - baseline_latency)
+gas increase           = max(0, observed_gas_log - baseline_gas_log)
+```
+
+A deterministic linear quantile is then computed for each declared policy quantile. Rate magnitudes are returned as negative shifts. Cost and gas increases remain non-negative.
+
+The default policy emits:
+
+- a zero-shift calibrated baseline;
+- empirical 50th-percentile adverse state;
+- empirical 80th-percentile adverse state;
+- empirical 95th-percentile adverse state.
+
+All outputs are clipped to explicit scenario-contract bounds. Every clip is counted in the receipt.
+
+## Receipt
+
+The calibration receipt binds:
+
+- baseline snapshot SHA-256;
+- triangular candidate identity;
+- sorted observation identities;
+- complete source-bound dataset digest;
+- calibration-policy digest;
+- generated scenario-set digest;
+- observation count;
+- clip counters;
+- `authority: false`.
+
+The generated `PerturbationScenario` objects can be passed directly into the Phase 2C-1 Rust-backed robustness evaluator.
+
+## Interpretation boundary
+
+The scenarios describe empirical stress magnitudes present in the supplied observation corpus. They are not guaranteed probabilities, forecasts, confidence intervals, or claims about future market behavior.
+
+A small, biased, stale, synthetic, or incomplete corpus produces correspondingly limited evidence. The receipt preserves lineage so those limitations can be audited instead of hidden.
+
+## Design law
+
+```text
+History may calibrate pressure.
+History may not promise recurrence.
+Source hashes bind the evidence.
+Quantiles describe the supplied corpus.
+Clipping must be visible.
+Calibration cannot grant authority.
+Rust still verifies every perturbed route.
+Human review remains the promotion gate.
+```
+
+## Deferred work
+
+- ingestion adapters for independently archived venue snapshots;
+- corpus quality and staleness scoring;
+- regime segmentation;
+- rolling-window comparison receipts;
+- benchmark corpus generation;
+- canonical simulation-receipt emission;
+- fork and testnet shadow observation.

--- a/eve_q/perturbation_calibration.py
+++ b/eve_q/perturbation_calibration.py
@@ -1,0 +1,379 @@
+"""Deterministic, source-bound calibration of adverse market perturbations.
+
+The module converts historical route-aligned observations into bounded
+``PerturbationScenario`` objects. It performs no market discovery, networking,
+trading, scheduling, borrowing, signing, or capital movement. Calibration
+receipts are research evidence and always retain ``authority: false``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from eve_q.delta_robustness import PerturbationScenario
+from eve_q.qaoa_delta import MarketEdge, TriangularCycle
+
+_BPS = 10_000.0
+
+
+def _require_sha256(value: str, field_name: str) -> None:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{field_name} must be 64 lowercase hexadecimal characters")
+
+
+def _stable_sha256(payload: object) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _linear_quantile(values: Sequence[float], quantile: float) -> float:
+    if not values:
+        raise ValueError("quantile values cannot be empty")
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * quantile
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+@dataclass(frozen=True)
+class HistoricalEdgeObservation:
+    edge_id: str
+    quoted_rate: float
+    fee_bps: float = 0.0
+    slippage_bps: float = 0.0
+    latency_penalty_bps: float = 0.0
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.edge_id.strip():
+            raise ValueError("edge_id is required")
+        if not math.isfinite(self.quoted_rate) or self.quoted_rate <= 0.0:
+            raise ValueError("quoted_rate must be finite and positive")
+        for field_name, value in (
+            ("fee_bps", self.fee_bps),
+            ("slippage_bps", self.slippage_bps),
+            ("latency_penalty_bps", self.latency_penalty_bps),
+        ):
+            if not math.isfinite(value) or not 0.0 <= value < _BPS:
+                raise ValueError(f"{field_name} must be finite in [0, 10000)")
+        if self.authority:
+            raise ValueError("historical edge observations cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "edge_id": self.edge_id,
+            "quoted_rate": self.quoted_rate,
+            "fee_bps": self.fee_bps,
+            "slippage_bps": self.slippage_bps,
+            "latency_penalty_bps": self.latency_penalty_bps,
+            "authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class HistoricalMarketObservation:
+    observation_id: str
+    observed_at: str
+    edges: tuple[HistoricalEdgeObservation, HistoricalEdgeObservation, HistoricalEdgeObservation]
+    gas_penalty_log: float
+    source_sha256: str
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.observation_id.startswith("market-observation:"):
+            raise ValueError("observation_id must use the market-observation namespace")
+        if not self.observed_at.strip():
+            raise ValueError("observed_at is required")
+        if len(self.edges) != 3:
+            raise ValueError("historical observations must contain exactly three edges")
+        edge_ids = [edge.edge_id for edge in self.edges]
+        if len(set(edge_ids)) != 3:
+            raise ValueError("historical observation edge identifiers must be unique")
+        if not math.isfinite(self.gas_penalty_log) or self.gas_penalty_log < 0.0:
+            raise ValueError("gas_penalty_log must be finite and non-negative")
+        _require_sha256(self.source_sha256, "source_sha256")
+        if self.authority:
+            raise ValueError("historical market observations cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "observation_id": self.observation_id,
+            "observed_at": self.observed_at,
+            "edges": [edge.as_dict() for edge in sorted(self.edges, key=lambda item: item.edge_id)],
+            "gas_penalty_log": self.gas_penalty_log,
+            "source_sha256": self.source_sha256,
+            "authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class PerturbationCalibrationPolicy:
+    quantiles: tuple[float, ...] = (0.50, 0.80, 0.95)
+    minimum_observations: int = 3
+    maximum_observations: int = 4096
+    max_abs_rate_shift_bps: float = 5_000.0
+    max_cost_shift_bps: float = 5_000.0
+    max_gas_shift_log: float = 5.0
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.quantiles:
+            raise ValueError("at least one calibration quantile is required")
+        if tuple(sorted(set(self.quantiles))) != self.quantiles:
+            raise ValueError("quantiles must be unique and strictly increasing")
+        if any(not math.isfinite(value) or not 0.0 < value <= 1.0 for value in self.quantiles):
+            raise ValueError("quantiles must be finite in (0, 1]")
+        if self.minimum_observations < 1:
+            raise ValueError("minimum_observations must be positive")
+        if self.maximum_observations < self.minimum_observations:
+            raise ValueError("maximum_observations must not be below minimum_observations")
+        for field_name, value in (
+            ("max_abs_rate_shift_bps", self.max_abs_rate_shift_bps),
+            ("max_cost_shift_bps", self.max_cost_shift_bps),
+            ("max_gas_shift_log", self.max_gas_shift_log),
+        ):
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{field_name} must be finite and positive")
+        if self.max_abs_rate_shift_bps > 5_000.0:
+            raise ValueError("max_abs_rate_shift_bps cannot exceed the scenario contract")
+        if self.max_cost_shift_bps > 5_000.0:
+            raise ValueError("max_cost_shift_bps cannot exceed the scenario contract")
+        if self.authority:
+            raise ValueError("calibration policies cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "quantiles": list(self.quantiles),
+            "minimum_observations": self.minimum_observations,
+            "maximum_observations": self.maximum_observations,
+            "max_abs_rate_shift_bps": self.max_abs_rate_shift_bps,
+            "max_cost_shift_bps": self.max_cost_shift_bps,
+            "max_gas_shift_log": self.max_gas_shift_log,
+            "authority": False,
+        }
+
+
+@dataclass(frozen=True)
+class PerturbationCalibrationReceipt:
+    receipt_id: str
+    baseline_snapshot_sha256: str
+    candidate_id: str
+    dataset_sha256: str
+    policy_sha256: str
+    scenario_set_sha256: str
+    observation_count: int
+    observation_ids: tuple[str, ...]
+    policy: PerturbationCalibrationPolicy
+    scenarios: tuple[PerturbationScenario, ...]
+    clipped_counts: Mapping[str, int]
+    authority: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.receipt_id.startswith("perturbation-calibration:"):
+            raise ValueError("receipt_id must use the perturbation-calibration namespace")
+        _require_sha256(self.baseline_snapshot_sha256, "baseline_snapshot_sha256")
+        _require_sha256(self.dataset_sha256, "dataset_sha256")
+        _require_sha256(self.policy_sha256, "policy_sha256")
+        _require_sha256(self.scenario_set_sha256, "scenario_set_sha256")
+        if not self.candidate_id.startswith("triangle:"):
+            raise ValueError("candidate_id must use the triangle namespace")
+        if self.observation_count != len(self.observation_ids):
+            raise ValueError("observation_count must match observation_ids")
+        if tuple(sorted(set(self.observation_ids))) != self.observation_ids:
+            raise ValueError("observation_ids must be unique and sorted")
+        if len(self.scenarios) != len(self.policy.quantiles) + 1:
+            raise ValueError("scenarios must contain a baseline plus one scenario per quantile")
+        if self.scenarios[0].scenario_id != "delta-scenario:calibrated-baseline":
+            raise ValueError("the calibrated baseline scenario must be first")
+        if any(value < 0 for value in self.clipped_counts.values()):
+            raise ValueError("clipped counts cannot be negative")
+        if self.authority:
+            raise ValueError("calibration receipts cannot grant authority")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": "perturbation-calibration-receipt-v0.1",
+            "receipt_id": self.receipt_id,
+            "baseline_snapshot_sha256": self.baseline_snapshot_sha256,
+            "candidate_id": self.candidate_id,
+            "dataset_sha256": self.dataset_sha256,
+            "policy_sha256": self.policy_sha256,
+            "scenario_set_sha256": self.scenario_set_sha256,
+            "observation_count": self.observation_count,
+            "observation_ids": list(self.observation_ids),
+            "policy": self.policy.as_dict(),
+            "scenarios": [scenario.as_dict() for scenario in self.scenarios],
+            "clipped_counts": dict(sorted(self.clipped_counts.items())),
+            "authority": False,
+        }
+
+
+def _cap(value: float, maximum: float, field_name: str, counts: dict[str, int]) -> float:
+    if value > maximum:
+        counts[field_name] = counts.get(field_name, 0) + 1
+        return maximum
+    return value
+
+
+def calibrate_perturbation_scenarios(
+    candidate: TriangularCycle,
+    baseline_edges: Sequence[MarketEdge],
+    observations: Sequence[HistoricalMarketObservation],
+    *,
+    baseline_snapshot_sha256: str,
+    policy: PerturbationCalibrationPolicy | None = None,
+) -> PerturbationCalibrationReceipt:
+    """Calibrate bounded adverse scenarios from source-bound historical observations."""
+
+    _require_sha256(baseline_snapshot_sha256, "baseline_snapshot_sha256")
+    policy = policy or PerturbationCalibrationPolicy()
+    if not policy.minimum_observations <= len(observations) <= policy.maximum_observations:
+        raise ValueError(
+            "observation count must remain within the calibration policy bounds"
+        )
+
+    baseline_by_id = {edge.edge_id: edge for edge in baseline_edges}
+    if len(baseline_by_id) != len(baseline_edges):
+        raise ValueError("baseline edge identifiers must be unique")
+    if set(baseline_by_id) != set(candidate.edge_ids):
+        raise ValueError("baseline edges must match the candidate edge set")
+    ordered_baseline = tuple(baseline_by_id[edge_id] for edge_id in candidate.edge_ids)
+
+    ordered_observations = tuple(sorted(observations, key=lambda item: item.observation_id))
+    observation_ids = tuple(item.observation_id for item in ordered_observations)
+    if len(set(observation_ids)) != len(observation_ids):
+        raise ValueError("observation identifiers must be unique")
+
+    rate_adverse_magnitudes: list[list[float]] = [[], [], []]
+    fee_increases: list[list[float]] = [[], [], []]
+    slippage_increases: list[list[float]] = [[], [], []]
+    latency_increases: list[list[float]] = [[], [], []]
+    gas_increases: list[float] = []
+
+    for observation in ordered_observations:
+        observed_by_id = {edge.edge_id: edge for edge in observation.edges}
+        if set(observed_by_id) != set(candidate.edge_ids):
+            raise ValueError(
+                f"observation {observation.observation_id!r} must match the candidate edge set"
+            )
+        for index, baseline in enumerate(ordered_baseline):
+            observed = observed_by_id[baseline.edge_id]
+            rate_shift = (observed.quoted_rate / baseline.quoted_rate - 1.0) * _BPS
+            rate_adverse_magnitudes[index].append(max(0.0, -rate_shift))
+            fee_increases[index].append(max(0.0, observed.fee_bps - baseline.fee_bps))
+            slippage_increases[index].append(
+                max(0.0, observed.slippage_bps - baseline.slippage_bps)
+            )
+            latency_increases[index].append(
+                max(0.0, observed.latency_penalty_bps - baseline.latency_penalty_bps)
+            )
+        gas_increases.append(max(0.0, observation.gas_penalty_log - candidate.gas_penalty_log))
+
+    clipped_counts: dict[str, int] = {
+        "rate_shift_bps": 0,
+        "fee_shift_bps": 0,
+        "slippage_shift_bps": 0,
+        "latency_shift_bps": 0,
+        "gas_penalty_log_shift": 0,
+    }
+    scenarios: list[PerturbationScenario] = [
+        PerturbationScenario("delta-scenario:calibrated-baseline")
+    ]
+    for quantile in policy.quantiles:
+        token = f"q{round(quantile * 10_000):04d}"
+        rate_shift = tuple(
+            -_cap(
+                _linear_quantile(rate_adverse_magnitudes[index], quantile),
+                policy.max_abs_rate_shift_bps,
+                "rate_shift_bps",
+                clipped_counts,
+            )
+            for index in range(3)
+        )
+        fee_shift = tuple(
+            _cap(
+                _linear_quantile(fee_increases[index], quantile),
+                policy.max_cost_shift_bps,
+                "fee_shift_bps",
+                clipped_counts,
+            )
+            for index in range(3)
+        )
+        slippage_shift = tuple(
+            _cap(
+                _linear_quantile(slippage_increases[index], quantile),
+                policy.max_cost_shift_bps,
+                "slippage_shift_bps",
+                clipped_counts,
+            )
+            for index in range(3)
+        )
+        latency_shift = tuple(
+            _cap(
+                _linear_quantile(latency_increases[index], quantile),
+                policy.max_cost_shift_bps,
+                "latency_shift_bps",
+                clipped_counts,
+            )
+            for index in range(3)
+        )
+        gas_shift = _cap(
+            _linear_quantile(gas_increases, quantile),
+            policy.max_gas_shift_log,
+            "gas_penalty_log_shift",
+            clipped_counts,
+        )
+        scenarios.append(
+            PerturbationScenario(
+                f"delta-scenario:calibrated-{token}",
+                rate_shift_bps=rate_shift,
+                fee_shift_bps=fee_shift,
+                slippage_shift_bps=slippage_shift,
+                latency_shift_bps=latency_shift,
+                gas_penalty_log_shift=gas_shift,
+            )
+        )
+
+    scenario_ids = [scenario.scenario_id for scenario in scenarios]
+    if len(set(scenario_ids)) != len(scenario_ids):
+        raise ValueError("calibration quantiles produced duplicate scenario identifiers")
+
+    dataset_payload = [item.as_dict() for item in ordered_observations]
+    dataset_sha256 = _stable_sha256(dataset_payload)
+    policy_sha256 = _stable_sha256(policy.as_dict())
+    scenario_set_sha256 = _stable_sha256([scenario.as_dict() for scenario in scenarios])
+    receipt_seed = {
+        "baseline_snapshot_sha256": baseline_snapshot_sha256,
+        "candidate_id": candidate.candidate_id,
+        "dataset_sha256": dataset_sha256,
+        "policy_sha256": policy_sha256,
+        "scenario_set_sha256": scenario_set_sha256,
+        "observation_ids": list(observation_ids),
+        "clipped_counts": dict(sorted(clipped_counts.items())),
+        "authority": False,
+    }
+    receipt_hash = _stable_sha256(receipt_seed)
+
+    return PerturbationCalibrationReceipt(
+        receipt_id=f"perturbation-calibration:{receipt_hash[:24]}",
+        baseline_snapshot_sha256=baseline_snapshot_sha256,
+        candidate_id=candidate.candidate_id,
+        dataset_sha256=dataset_sha256,
+        policy_sha256=policy_sha256,
+        scenario_set_sha256=scenario_set_sha256,
+        observation_count=len(ordered_observations),
+        observation_ids=observation_ids,
+        policy=policy,
+        scenarios=tuple(scenarios),
+        clipped_counts=clipped_counts,
+    )

--- a/schemas/perturbation_calibration_receipt.schema.json
+++ b/schemas/perturbation_calibration_receipt.schema.json
@@ -1,0 +1,121 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://architectofathena.github.io/CodexTradingEngine/schemas/perturbation_calibration_receipt.schema.json",
+  "title": "Perturbation Calibration Receipt",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "receipt_id",
+    "baseline_snapshot_sha256",
+    "candidate_id",
+    "dataset_sha256",
+    "policy_sha256",
+    "scenario_set_sha256",
+    "observation_count",
+    "observation_ids",
+    "policy",
+    "scenarios",
+    "clipped_counts",
+    "authority"
+  ],
+  "properties": {
+    "schema_version": {"const": "perturbation-calibration-receipt-v0.1"},
+    "receipt_id": {"type": "string", "pattern": "^perturbation-calibration:[0-9a-f]{24}$"},
+    "baseline_snapshot_sha256": {"$ref": "#/$defs/sha256"},
+    "candidate_id": {"type": "string", "pattern": "^triangle:[0-9a-f]{20}$"},
+    "dataset_sha256": {"$ref": "#/$defs/sha256"},
+    "policy_sha256": {"$ref": "#/$defs/sha256"},
+    "scenario_set_sha256": {"$ref": "#/$defs/sha256"},
+    "observation_count": {"type": "integer", "minimum": 1, "maximum": 4096},
+    "observation_ids": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 4096,
+      "uniqueItems": true,
+      "items": {"type": "string", "pattern": "^market-observation:"}
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "quantiles",
+        "minimum_observations",
+        "maximum_observations",
+        "max_abs_rate_shift_bps",
+        "max_cost_shift_bps",
+        "max_gas_shift_log",
+        "authority"
+      ],
+      "properties": {
+        "quantiles": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "number", "exclusiveMinimum": 0, "maximum": 1}
+        },
+        "minimum_observations": {"type": "integer", "minimum": 1},
+        "maximum_observations": {"type": "integer", "minimum": 1, "maximum": 4096},
+        "max_abs_rate_shift_bps": {"type": "number", "exclusiveMinimum": 0, "maximum": 5000},
+        "max_cost_shift_bps": {"type": "number", "exclusiveMinimum": 0, "maximum": 5000},
+        "max_gas_shift_log": {"type": "number", "exclusiveMinimum": 0},
+        "authority": {"const": false}
+      }
+    },
+    "scenarios": {
+      "type": "array",
+      "minItems": 2,
+      "items": {"$ref": "#/$defs/scenario"}
+    },
+    "clipped_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "rate_shift_bps",
+        "fee_shift_bps",
+        "slippage_shift_bps",
+        "latency_shift_bps",
+        "gas_penalty_log_shift"
+      ],
+      "properties": {
+        "rate_shift_bps": {"type": "integer", "minimum": 0},
+        "fee_shift_bps": {"type": "integer", "minimum": 0},
+        "slippage_shift_bps": {"type": "integer", "minimum": 0},
+        "latency_shift_bps": {"type": "integer", "minimum": 0},
+        "gas_penalty_log_shift": {"type": "integer", "minimum": 0}
+      }
+    },
+    "authority": {"const": false}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "vector3": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {"type": "number"}
+    },
+    "scenario": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scenario_id",
+        "rate_shift_bps",
+        "fee_shift_bps",
+        "slippage_shift_bps",
+        "latency_shift_bps",
+        "gas_penalty_log_shift",
+        "authority"
+      ],
+      "properties": {
+        "scenario_id": {"type": "string", "pattern": "^delta-scenario:calibrated-"},
+        "rate_shift_bps": {"$ref": "#/$defs/vector3"},
+        "fee_shift_bps": {"$ref": "#/$defs/vector3"},
+        "slippage_shift_bps": {"$ref": "#/$defs/vector3"},
+        "latency_shift_bps": {"$ref": "#/$defs/vector3"},
+        "gas_penalty_log_shift": {"type": "number", "minimum": 0},
+        "authority": {"const": false}
+      }
+    }
+  }
+}

--- a/tests/test_perturbation_calibration.py
+++ b/tests/test_perturbation_calibration.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import pytest
+
+from eve_q.perturbation_calibration import (
+    HistoricalEdgeObservation,
+    HistoricalMarketObservation,
+    PerturbationCalibrationPolicy,
+    calibrate_perturbation_scenarios,
+)
+from eve_q.qaoa_delta import MarketEdge, enumerate_triangular_cycles
+
+
+def _fixture():
+    edges = (
+        MarketEdge("usd-eth", "USD", "ETH", 0.0005, venue="alpha"),
+        MarketEdge("eth-btc", "ETH", "BTC", 0.05, venue="beta"),
+        MarketEdge("btc-usd", "BTC", "USD", 41_000.0, venue="gamma"),
+    )
+    candidate = enumerate_triangular_cycles(edges)[0]
+    baseline_by_id = {edge.edge_id: edge for edge in edges}
+
+    observations = []
+    for index, adverse_bps in enumerate((10.0, 20.0, 30.0), start=1):
+        observed_edges = tuple(
+            HistoricalEdgeObservation(
+                edge_id=edge_id,
+                quoted_rate=baseline_by_id[edge_id].quoted_rate * (1.0 - adverse_bps / 10_000.0),
+                fee_bps=float(index),
+                slippage_bps=float(index * 2),
+                latency_penalty_bps=float(index * 3),
+            )
+            for edge_id in reversed(candidate.edge_ids)
+        )
+        observations.append(
+            HistoricalMarketObservation(
+                observation_id=f"market-observation:{index}",
+                observed_at=f"2026-07-0{index}T00:00:00Z",
+                edges=observed_edges,
+                gas_penalty_log=index * 0.001,
+                source_sha256=f"{index}" * 64,
+            )
+        )
+    return edges, candidate, tuple(observations)
+
+
+def test_calibration_is_deterministic_and_order_independent() -> None:
+    edges, candidate, observations = _fixture()
+
+    first = calibrate_perturbation_scenarios(
+        candidate,
+        edges,
+        observations,
+        baseline_snapshot_sha256="a" * 64,
+    )
+    second = calibrate_perturbation_scenarios(
+        candidate,
+        tuple(reversed(edges)),
+        tuple(reversed(observations)),
+        baseline_snapshot_sha256="a" * 64,
+    )
+
+    assert first == second
+    assert first.observation_count == 3
+    assert first.observation_ids == (
+        "market-observation:1",
+        "market-observation:2",
+        "market-observation:3",
+    )
+    assert len(first.scenarios) == 4
+    assert first.scenarios[0].scenario_id == "delta-scenario:calibrated-baseline"
+    assert all(scenario.authority is False for scenario in first.scenarios)
+    assert first.authority is False
+
+
+def test_calibration_derives_expected_adverse_quantiles() -> None:
+    edges, candidate, observations = _fixture()
+
+    receipt = calibrate_perturbation_scenarios(
+        candidate,
+        edges,
+        observations,
+        baseline_snapshot_sha256="b" * 64,
+    )
+
+    median = receipt.scenarios[1]
+    assert median.scenario_id == "delta-scenario:calibrated-q5000"
+    assert median.rate_shift_bps == pytest.approx((-20.0, -20.0, -20.0))
+    assert median.fee_shift_bps == pytest.approx((2.0, 2.0, 2.0))
+    assert median.slippage_shift_bps == pytest.approx((4.0, 4.0, 4.0))
+    assert median.latency_shift_bps == pytest.approx((6.0, 6.0, 6.0))
+    assert median.gas_penalty_log_shift == pytest.approx(0.002)
+
+    hard = receipt.scenarios[-1]
+    assert hard.scenario_id == "delta-scenario:calibrated-q9500"
+    assert hard.rate_shift_bps == pytest.approx((-29.0, -29.0, -29.0))
+    assert hard.fee_shift_bps == pytest.approx((2.9, 2.9, 2.9))
+    assert hard.slippage_shift_bps == pytest.approx((5.8, 5.8, 5.8))
+    assert hard.latency_shift_bps == pytest.approx((8.7, 8.7, 8.7))
+    assert hard.gas_penalty_log_shift == pytest.approx(0.0029)
+
+
+def test_calibration_clips_to_declared_policy_bounds() -> None:
+    edges, candidate, observations = _fixture()
+    policy = PerturbationCalibrationPolicy(
+        quantiles=(0.95,),
+        minimum_observations=3,
+        max_abs_rate_shift_bps=15.0,
+        max_cost_shift_bps=4.0,
+        max_gas_shift_log=0.002,
+    )
+
+    receipt = calibrate_perturbation_scenarios(
+        candidate,
+        edges,
+        observations,
+        baseline_snapshot_sha256="c" * 64,
+        policy=policy,
+    )
+
+    scenario = receipt.scenarios[1]
+    assert scenario.rate_shift_bps == pytest.approx((-15.0, -15.0, -15.0))
+    assert scenario.fee_shift_bps == pytest.approx((2.9, 2.9, 2.9))
+    assert scenario.slippage_shift_bps == pytest.approx((4.0, 4.0, 4.0))
+    assert scenario.latency_shift_bps == pytest.approx((4.0, 4.0, 4.0))
+    assert scenario.gas_penalty_log_shift == pytest.approx(0.002)
+    assert receipt.clipped_counts["rate_shift_bps"] == 3
+    assert receipt.clipped_counts["slippage_shift_bps"] == 3
+    assert receipt.clipped_counts["latency_shift_bps"] == 3
+    assert receipt.clipped_counts["gas_penalty_log_shift"] == 1
+
+
+def test_calibration_rejects_route_mismatch_and_authority_escalation() -> None:
+    edges, candidate, observations = _fixture()
+    mismatched = HistoricalMarketObservation(
+        observation_id="market-observation:mismatch",
+        observed_at="2026-07-04T00:00:00Z",
+        edges=(
+            HistoricalEdgeObservation("wrong-a", 1.0),
+            HistoricalEdgeObservation("wrong-b", 1.0),
+            HistoricalEdgeObservation("wrong-c", 1.0),
+        ),
+        gas_penalty_log=0.0,
+        source_sha256="d" * 64,
+    )
+
+    with pytest.raises(ValueError, match="must match the candidate edge set"):
+        calibrate_perturbation_scenarios(
+            candidate,
+            edges,
+            observations[:2] + (mismatched,),
+            baseline_snapshot_sha256="d" * 64,
+        )
+
+    with pytest.raises(ValueError, match="cannot grant authority"):
+        HistoricalEdgeObservation("forbidden", 1.0, authority=True)
+
+    with pytest.raises(ValueError, match="cannot grant authority"):
+        PerturbationCalibrationPolicy(authority=True)


### PR DESCRIPTION
## Summary

Implements Phase 2D of the hybrid delta engine: deterministic, source-bound calibration of adverse route perturbations from supplied historical market observations.

## Included

- strict historical edge and market-observation contracts
- route alignment by stable edge identity rather than tuple order
- deterministic linear empirical quantiles
- adverse rate, fee, slippage, latency, and gas derivation
- explicit calibration policy and bounded clipping
- clipping counters preserved in evidence
- SHA-256 binding for source corpus, policy, and scenario set
- calibration receipt schema
- Python 3.11/3.13 tests
- canonical README and architecture documentation

## GitHub validation

All dedicated gates passed on the current head:

- Python 3.11 hybrid core: PASS
- Python 3.13 hybrid core: PASS
- Qiskit 2.5 adapter: PASS
- stable Rust exact verifiers: PASS
- real Python → Rust repricing, robustness, and flash-liquidity bridge: PASS
- perturbation calibration tests and schema syntax: PASS

## Design law

```text
History may calibrate pressure.
History may not promise recurrence.
Source hashes bind the evidence.
Quantiles describe the supplied corpus.
Clipping must be visible.
Calibration cannot grant authority.
Rust still verifies every perturbed route.
Human review remains the promotion gate.
```

## Boundaries

- offline supplied observations only
- no venue or provider discovery
- no feed subscription
- no wallet or transaction signing
- no RPC submission
- no borrowing or capital movement
- no scheduler authority
- all observations, policies, scenarios, and receipts retain `authority: false`

## Scope

This phase calibrates empirical adverse magnitudes for the existing Rust-backed robustness engine. Corpus quality scoring, regime segmentation, rolling windows, benchmark snapshots, canonical simulation-receipt emission, and fork/testnet shadow observation remain later bounded phases tracked by issue #48.

## Human gate

The branch is validated, mergeable, and ready for review. No live execution authority is introduced.