### PR TITLE
EVE_Q++ gate descent controller v0.1

### DIFF
--- a/.github/workflows/eve-q-gate-descent-ci.yml
+++ b/.github/workflows/eve-q-gate-descent-ci.yml
@@ -1,0 +1,62 @@
+name: EVE_Q++ Gate Descent CI
+
+on:
+  pull_request:
+    paths:
+      - "eve_q/gate_descent.py"
+      - "schemas/gate_descent_proposal_v0_1.schema.json"
+      - "examples/governance/gate_descent_g0_to_g1_draft_v0_1.json"
+      - "tests/test_gate_descent_v0_1.py"
+      - "docs/governance/EVE_Q_GATE_DESCENT_v0_1.md"
+      - ".github/workflows/eve-q-gate-descent-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "eve_q/gate_descent.py"
+      - "schemas/gate_descent_proposal_v0_1.schema.json"
+      - "examples/governance/gate_descent_g0_to_g1_draft_v0_1.json"
+      - "tests/test_gate_descent_v0_1.py"
+      - "docs/governance/EVE_Q_GATE_DESCENT_v0_1.md"
+      - ".github/workflows/eve-q-gate-descent-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  gate-descent:
+    name: Gate descent controller (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install development dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Compile controller
+        run: |
+          python -m py_compile eve_q/gate_descent.py
+
+      - name: Run gate descent tests
+        run: |
+          python -m pytest -q --no-cov tests/test_gate_descent_v0_1.py
+
+      - name: Validate canonical draft example
+        run: |
+          python -m eve_q.gate_descent \
+            --validate examples/governance/gate_descent_g0_to_g1_draft_v0_1.json \
+            --now 2026-07-11T21:05:00Z

--- a/docs/governance/EVE_Q_GATE_DESCENT_v0_1.md
+++ b/docs/governance/EVE_Q_GATE_DESCENT_v0_1.md
@@ -1,0 +1,126 @@
+# EVE_Q++ Gate Descent v0.1
+
+## Purpose
+
+EVE_Q++ is not intended to remain permanently sealed at simulation-only capability. It is intended to earn capability through staged, reversible, evidence-backed gate descent.
+
+The law is:
+
+```text
+lower one gate
+→ keep every downstream gate closed
+→ observe
+→ perturb
+→ audit
+→ prove rollback
+→ earn the next gate
+```
+
+Passing one gate never grants authority at another gate.
+
+## Capability ladder
+
+| Gate | Name | Meaning |
+|---:|---|---|
+| 0 | `SIMULATION_ONLY` | Deterministic simulation, proposals, evidence, registry, receipts; no live authority. |
+| 1 | `LIVE_READ_ONLY_TELEMETRY` | Live observations may enter through read-only interfaces and become content-addressed snapshots. |
+| 2 | `LIVE_PROPOSAL_GENERATION` | Live observations may inform non-command proposals for human review. |
+| 3 | `TESTNET_MANUAL_EXTERNAL` | A human may perform a bounded external testnet action after explicit promotion. Artifacts still do not execute. |
+| 4 | `CAPPED_MANUAL_EXTERNAL` | A human may perform a tightly capped live action outside the system after per-action promotion. |
+| 5 | `EXECUTION_ASSISTANCE` | Future unsigned assistance, requiring a separate threat model and constitutional review. |
+| 6 | `NARROW_AUTOMATION` | Future narrowly scoped automation, requiring a separate release contract. |
+
+## v0.1 scope
+
+This release encodes only the proposed transition:
+
+```text
+Gate 0: ACTIVE
+Gate 1: REQUESTED
+Gate 2–6: LOCKED
+```
+
+The controller does **not** lower Gate 1. It creates and validates a non-authoritative `GateDescentProposal` that can become eligible for human review only after its evidence requirements are satisfied.
+
+## Required invariants
+
+Every proposal must preserve:
+
+```json
+{
+  "artifact_is_command": false,
+  "authority": false,
+  "human_promotion_required": true,
+  "may_execute": false,
+  "may_move_capital": false,
+  "connector_mode": "read_only",
+  "write_capable_secrets_present": false
+}
+```
+
+The controller rejects:
+
+- skipped gates;
+- more than one requested gate;
+- any downstream gate opened early;
+- stale or inconsistent TTL;
+- canonical artifact hash mismatch;
+- write-capable connector mode;
+- write-capable secrets;
+- missing prohibited actions;
+- premature promotion eligibility;
+- a ready state with incomplete checks;
+- a ready state without the required evidence classes;
+- a ready state without a tested rollback to Gate 0;
+- any authority, execution, or capital-movement leakage.
+
+## Gate 1 evidence contract
+
+`READY_FOR_HUMAN_REVIEW` requires all checks below to be true:
+
+- adjacent gate only;
+- all downstream gates locked;
+- read-only interfaces only;
+- zero write-capable secrets;
+- live inputs content-addressed;
+- replayable snapshots retained;
+- stale-input rejection proven;
+- malformed-input rejection proven;
+- source-outage behavior proven;
+- rollback to simulation proven;
+- bounded live-read-only soak passed;
+- no execution surface introduced.
+
+It also requires content-addressed evidence for:
+
+- the existing simulation baseline soak;
+- a new live-read-only telemetry soak;
+- a rollback test;
+- a threat model.
+
+A ready proposal is still only eligible for **human review**. It remains non-command and non-executing.
+
+## CLI
+
+Create a draft:
+
+```bash
+python -m eve_q.gate_descent \
+  --write-draft artifacts/governance/gate_descent_g0_to_g1.json \
+  --created-at 2026-07-11T21:00:00Z \
+  --expires-at 2026-07-12T21:00:00Z
+```
+
+Validate a proposal:
+
+```bash
+python -m eve_q.gate_descent \
+  --validate artifacts/governance/gate_descent_g0_to_g1.json \
+  --now 2026-07-11T21:05:00Z
+```
+
+## Current posture
+
+Gate 0 remains active. Gate 1 is a requested future capability, not an enabled one.
+
+> The gate opens because evidence and rollback have earned it, not because the previous gate succeeded.

--- a/eve_q/gate_descent.py
+++ b/eve_q/gate_descent.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CONTRACT_VERSION = "eve_q_gate_descent_v0.1"
+ARTIFACT_TYPE = "GateDescentProposal"
+MAX_TTL_SECONDS = 86_400
+
+GATES: tuple[str, ...] = (
+    "SIMULATION_ONLY",
+    "LIVE_READ_ONLY_TELEMETRY",
+    "LIVE_PROPOSAL_GENERATION",
+    "TESTNET_MANUAL_EXTERNAL",
+    "CAPPED_MANUAL_EXTERNAL",
+    "EXECUTION_ASSISTANCE",
+    "NARROW_AUTOMATION",
+)
+
+REQUIRED_PROHIBITED_ACTIONS = frozenset(
+    {
+        "wallet_access",
+        "signing",
+        "order_submission",
+        "transaction_construction",
+        "transaction_broadcast",
+        "capital_movement",
+        "self_promotion",
+        "multi_gate_descent",
+    }
+)
+
+READY_EVIDENCE_TYPES = frozenset(
+    {
+        "baseline_soak",
+        "live_read_only_soak",
+        "rollback_test",
+        "threat_model",
+    }
+)
+
+READY_CHECKS = frozenset(
+    {
+        "adjacent_gate_only",
+        "all_downstream_gates_locked",
+        "read_only_interfaces_only",
+        "zero_write_capable_secrets",
+        "live_inputs_content_addressed",
+        "replayable_snapshots_retained",
+        "stale_input_rejection_proven",
+        "malformed_input_rejection_proven",
+        "source_outage_behavior_proven",
+        "rollback_to_simulation_proven",
+        "bounded_live_read_only_soak_passed",
+        "no_execution_surface_introduced",
+    }
+)
+
+
+def canonical_json_bytes(document: dict[str, Any]) -> bytes:
+    return json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def artifact_payload(document: dict[str, Any]) -> dict[str, Any]:
+    payload = copy.deepcopy(document)
+    payload.pop("artifact_id", None)
+    return payload
+
+
+def compute_artifact_id(document: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json_bytes(artifact_payload(document))).hexdigest()
+
+
+def refresh_artifact_id(document: dict[str, Any]) -> dict[str, Any]:
+    refreshed = copy.deepcopy(document)
+    refreshed["artifact_id"] = compute_artifact_id(refreshed)
+    return refreshed
+
+
+def parse_utc(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include a UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def _evidence_types(document: dict[str, Any]) -> set[str]:
+    evidence = document.get("evidence", [])
+    if not isinstance(evidence, list):
+        return set()
+    return {
+        str(item.get("evidence_type"))
+        for item in evidence
+        if isinstance(item, dict) and item.get("evidence_type")
+    }
+
+
+def validate_gate_descent(
+    document: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> list[str]:
+    """Return semantic findings. An empty list means the proposal is valid."""
+    findings: list[str] = []
+    now_utc = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+    if document.get("artifact_type") != ARTIFACT_TYPE:
+        findings.append(f"artifact_type must be {ARTIFACT_TYPE}")
+    if document.get("contract_version") != CONTRACT_VERSION:
+        findings.append(f"contract_version must be {CONTRACT_VERSION}")
+
+    expected_id = compute_artifact_id(document)
+    if document.get("artifact_id") != expected_id:
+        findings.append("artifact_id does not match canonical payload hash")
+
+    try:
+        created_at = parse_utc(str(document["created_at"]))
+        expires_at = parse_utc(str(document["expires_at"]))
+        ttl_seconds = int(document["ttl_seconds"])
+    except (KeyError, TypeError, ValueError) as exc:
+        findings.append(f"invalid TTL fields: {exc}")
+    else:
+        actual_ttl = int((expires_at - created_at).total_seconds())
+        if ttl_seconds != actual_ttl:
+            findings.append("ttl_seconds does not match created_at/expires_at")
+        if ttl_seconds < 1 or ttl_seconds > MAX_TTL_SECONDS:
+            findings.append(f"ttl_seconds must be between 1 and {MAX_TTL_SECONDS}")
+        if expires_at <= now_utc:
+            findings.append("gate descent proposal TTL is stale")
+
+    gate_states = document.get("gate_states")
+    if not isinstance(gate_states, list) or len(gate_states) != len(GATES):
+        findings.append(f"gate_states must contain exactly {len(GATES)} gates")
+    else:
+        expected_statuses = ("ACTIVE", "REQUESTED") + ("LOCKED",) * (
+            len(GATES) - 2
+        )
+        for index, (expected_name, expected_status) in enumerate(
+            zip(GATES, expected_statuses, strict=True)
+        ):
+            gate = gate_states[index]
+            if not isinstance(gate, dict):
+                findings.append(f"gate_states[{index}] must be an object")
+                continue
+            if gate.get("index") != index:
+                findings.append(f"gate_states[{index}].index must equal {index}")
+            if gate.get("name") != expected_name:
+                findings.append(
+                    f"gate_states[{index}].name must equal {expected_name}"
+                )
+            if gate.get("status") != expected_status:
+                findings.append(
+                    f"gate_states[{index}].status must equal {expected_status}"
+                )
+
+    transition = document.get("transition", {})
+    if not isinstance(transition, dict):
+        findings.append("transition must be an object")
+    else:
+        current_gate = transition.get("current_gate")
+        requested_gate = transition.get("requested_gate")
+        if current_gate != 0 or requested_gate != 1:
+            findings.append("v0.1 permits only adjacent Gate 0 -> Gate 1")
+        if (
+            isinstance(current_gate, int)
+            and isinstance(requested_gate, int)
+            and requested_gate - current_gate != 1
+        ):
+            findings.append("exactly one adjacent gate may be requested")
+        if transition.get("one_gate_only") is not True:
+            findings.append("transition.one_gate_only must be true")
+        if transition.get("downstream_inheritance") is not False:
+            findings.append("transition.downstream_inheritance must be false")
+
+    for key, expected in {
+        "artifact_is_command": False,
+        "authority": False,
+        "human_promotion_required": True,
+        "may_execute": False,
+        "may_move_capital": False,
+        "write_capable_secrets_present": False,
+    }.items():
+        if document.get(key) is not expected:
+            findings.append(f"{key} must be {str(expected).lower()}")
+
+    if document.get("connector_mode") != "read_only":
+        findings.append("connector_mode must be read_only")
+
+    prohibited = document.get("prohibited_actions", [])
+    if not isinstance(prohibited, list):
+        findings.append("prohibited_actions must be an array")
+    else:
+        missing = sorted(REQUIRED_PROHIBITED_ACTIONS - set(map(str, prohibited)))
+        if missing:
+            findings.append(
+                "prohibited_actions missing required entries: " + ", ".join(missing)
+            )
+
+    readiness = document.get("readiness")
+    promotion_eligible = document.get("promotion_eligible")
+    checks = document.get("acceptance_checks", {})
+    rollback = document.get("rollback", {})
+    evidence_types = _evidence_types(document)
+
+    if not isinstance(checks, dict):
+        findings.append("acceptance_checks must be an object")
+        checks = {}
+    missing_checks = sorted(READY_CHECKS - set(checks))
+    if missing_checks:
+        findings.append("acceptance_checks missing: " + ", ".join(missing_checks))
+
+    if readiness == "DRAFT":
+        if promotion_eligible is not False:
+            findings.append("DRAFT proposals cannot be promotion eligible")
+    elif readiness == "READY_FOR_HUMAN_REVIEW":
+        if promotion_eligible is not True:
+            findings.append(
+                "READY_FOR_HUMAN_REVIEW requires promotion_eligible=true"
+            )
+        failed_checks = sorted(
+            check for check in READY_CHECKS if checks.get(check) is not True
+        )
+        if failed_checks:
+            findings.append(
+                "ready proposal has incomplete acceptance checks: "
+                + ", ".join(failed_checks)
+            )
+        missing_evidence = sorted(READY_EVIDENCE_TYPES - evidence_types)
+        if missing_evidence:
+            findings.append(
+                "ready proposal missing evidence types: "
+                + ", ".join(missing_evidence)
+            )
+        if not isinstance(rollback, dict) or rollback.get("tested") is not True:
+            findings.append("ready proposal requires a tested rollback")
+        elif rollback.get("target_gate") != 0:
+            findings.append("rollback target must be Gate 0")
+    else:
+        findings.append("readiness must be DRAFT or READY_FOR_HUMAN_REVIEW")
+
+    return findings
+
+
+def build_gate_0_to_1_draft(
+    *,
+    created_at: str,
+    expires_at: str,
+    evidence: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    checks = {name: False for name in sorted(READY_CHECKS)}
+    checks["adjacent_gate_only"] = True
+    checks["all_downstream_gates_locked"] = True
+    checks["read_only_interfaces_only"] = True
+    checks["zero_write_capable_secrets"] = True
+    checks["no_execution_surface_introduced"] = True
+
+    document: dict[str, Any] = {
+        "artifact_type": ARTIFACT_TYPE,
+        "contract_version": CONTRACT_VERSION,
+        "created_at": created_at,
+        "expires_at": expires_at,
+        "ttl_seconds": int(
+            (parse_utc(expires_at) - parse_utc(created_at)).total_seconds()
+        ),
+        "readiness": "DRAFT",
+        "promotion_eligible": False,
+        "transition": {
+            "current_gate": 0,
+            "requested_gate": 1,
+            "one_gate_only": True,
+            "downstream_inheritance": False,
+        },
+        "gate_states": [
+            {
+                "index": index,
+                "name": name,
+                "status": (
+                    "ACTIVE"
+                    if index == 0
+                    else "REQUESTED"
+                    if index == 1
+                    else "LOCKED"
+                ),
+            }
+            for index, name in enumerate(GATES)
+        ],
+        "connector_mode": "read_only",
+        "write_capable_secrets_present": False,
+        "acceptance_checks": checks,
+        "evidence": evidence or [],
+        "rollback": {
+            "target_gate": 0,
+            "tested": False,
+            "plan_sha256": None,
+            "test_receipt_sha256": None,
+        },
+        "prohibited_actions": sorted(REQUIRED_PROHIBITED_ACTIONS),
+        "artifact_is_command": False,
+        "authority": False,
+        "human_promotion_required": True,
+        "may_execute": False,
+        "may_move_capital": False,
+    }
+    return refresh_artifact_id(document)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build or validate an EVE_Q++ Gate 0 -> Gate 1 descent proposal."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--validate", type=Path)
+    group.add_argument("--write-draft", type=Path)
+    parser.add_argument("--created-at")
+    parser.add_argument("--expires-at")
+    parser.add_argument("--now")
+    args = parser.parse_args()
+
+    if args.write_draft:
+        if not args.created_at or not args.expires_at:
+            parser.error("--write-draft requires --created-at and --expires-at")
+        document = build_gate_0_to_1_draft(
+            created_at=args.created_at,
+            expires_at=args.expires_at,
+        )
+        args.write_draft.parent.mkdir(parents=True, exist_ok=True)
+        args.write_draft.write_text(
+            json.dumps(document, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(args.write_draft)
+        return 0
+
+    document = json.loads(args.validate.read_text(encoding="utf-8"))
+    now = parse_utc(args.now) if args.now else None
+    findings = validate_gate_descent(document, now=now)
+    if findings:
+        for finding in findings:
+            print(finding)
+        return 1
+    print("Gate descent proposal: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/governance/gate_descent_g0_to_g1_draft_v0_1.json
+++ b/examples/governance/gate_descent_g0_to_g1_draft_v0_1.json
@@ -1,0 +1,104 @@
+{
+  "acceptance_checks": {
+    "adjacent_gate_only": true,
+    "all_downstream_gates_locked": true,
+    "bounded_live_read_only_soak_passed": false,
+    "live_inputs_content_addressed": false,
+    "malformed_input_rejection_proven": false,
+    "no_execution_surface_introduced": true,
+    "read_only_interfaces_only": true,
+    "replayable_snapshots_retained": false,
+    "rollback_to_simulation_proven": false,
+    "source_outage_behavior_proven": false,
+    "stale_input_rejection_proven": false,
+    "zero_write_capable_secrets": true
+  },
+  "artifact_id": "5a84b864ee9d48bda85a89bb69ebb3f59d6fd67accc51fdf83afcfee1cb94827",
+  "artifact_is_command": false,
+  "artifact_type": "GateDescentProposal",
+  "authority": false,
+  "connector_mode": "read_only",
+  "contract_version": "eve_q_gate_descent_v0.1",
+  "created_at": "2026-07-11T21:00:00Z",
+  "evidence": [
+    {
+      "evidence_type": "baseline_soak",
+      "notes": "Illustrative content hash for the recorded 100-cycle baseline; replace with the verified file hash before review.",
+      "sha256": "7777777777777777777777777777777777777777777777777777777777777777",
+      "uri": "repo://docs/testing/results/EVE_Q_SOAK_RESULT_20260711T202544Z.json"
+    },
+    {
+      "evidence_type": "contract_lineage",
+      "notes": "Generation-2 lineage anchor; evidence only.",
+      "sha256": "f2a50e16cbed2ea06d561f2273ff1602ea649ab267d85ef543182b06341c5d8e",
+      "uri": "ipfs://bafkreig352tvdj5m4bimwc6hd256edsqzx32k6vqorpxs73z46eukpgwny"
+    }
+  ],
+  "expires_at": "2026-07-12T21:00:00Z",
+  "gate_states": [
+    {
+      "index": 0,
+      "name": "SIMULATION_ONLY",
+      "status": "ACTIVE"
+    },
+    {
+      "index": 1,
+      "name": "LIVE_READ_ONLY_TELEMETRY",
+      "status": "REQUESTED"
+    },
+    {
+      "index": 2,
+      "name": "LIVE_PROPOSAL_GENERATION",
+      "status": "LOCKED"
+    },
+    {
+      "index": 3,
+      "name": "TESTNET_MANUAL_EXTERNAL",
+      "status": "LOCKED"
+    },
+    {
+      "index": 4,
+      "name": "CAPPED_MANUAL_EXTERNAL",
+      "status": "LOCKED"
+    },
+    {
+      "index": 5,
+      "name": "EXECUTION_ASSISTANCE",
+      "status": "LOCKED"
+    },
+    {
+      "index": 6,
+      "name": "NARROW_AUTOMATION",
+      "status": "LOCKED"
+    }
+  ],
+  "human_promotion_required": true,
+  "may_execute": false,
+  "may_move_capital": false,
+  "prohibited_actions": [
+    "capital_movement",
+    "multi_gate_descent",
+    "order_submission",
+    "self_promotion",
+    "signing",
+    "transaction_broadcast",
+    "transaction_construction",
+    "wallet_access"
+  ],
+  "promotion_eligible": false,
+  "readiness": "DRAFT",
+  "rollback": {
+    "plan_sha256": null,
+    "target_gate": 0,
+    "test_receipt_sha256": null,
+    "tested": false
+  },
+  "transition": {
+    "current_gate": 0,
+    "downstream_inheritance": false,
+    "one_gate_only": true,
+    "requested_gate": 1
+  },
+  "ttl_seconds": 86400,
+  "write_capable_secrets_present": false
+}

--- a/schemas/gate_descent_proposal_v0_1.schema.json
+++ b/schemas/gate_descent_proposal_v0_1.schema.json
@@ -1,0 +1,337 @@
+{
+  "$id": "https://spiralbloom.local/schemas/gate_descent_proposal_v0_1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "readiness": {
+            "const": "DRAFT"
+          }
+        },
+        "required": [
+          "readiness"
+        ]
+      },
+      "then": {
+        "properties": {
+          "promotion_eligible": {
+            "const": false
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "readiness": {
+            "const": "READY_FOR_HUMAN_REVIEW"
+          }
+        },
+        "required": [
+          "readiness"
+        ]
+      },
+      "then": {
+        "properties": {
+          "promotion_eligible": {
+            "const": true
+          }
+        }
+      }
+    }
+  ],
+  "properties": {
+    "acceptance_checks": {
+      "additionalProperties": false,
+      "properties": {
+        "adjacent_gate_only": {
+          "type": "boolean"
+        },
+        "all_downstream_gates_locked": {
+          "type": "boolean"
+        },
+        "bounded_live_read_only_soak_passed": {
+          "type": "boolean"
+        },
+        "live_inputs_content_addressed": {
+          "type": "boolean"
+        },
+        "malformed_input_rejection_proven": {
+          "type": "boolean"
+        },
+        "no_execution_surface_introduced": {
+          "type": "boolean"
+        },
+        "read_only_interfaces_only": {
+          "type": "boolean"
+        },
+        "replayable_snapshots_retained": {
+          "type": "boolean"
+        },
+        "rollback_to_simulation_proven": {
+          "type": "boolean"
+        },
+        "source_outage_behavior_proven": {
+          "type": "boolean"
+        },
+        "stale_input_rejection_proven": {
+          "type": "boolean"
+        },
+        "zero_write_capable_secrets": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "adjacent_gate_only",
+        "all_downstream_gates_locked",
+        "read_only_interfaces_only",
+        "zero_write_capable_secrets",
+        "live_inputs_content_addressed",
+        "replayable_snapshots_retained",
+        "stale_input_rejection_proven",
+        "malformed_input_rejection_proven",
+        "source_outage_behavior_proven",
+        "rollback_to_simulation_proven",
+        "bounded_live_read_only_soak_passed",
+        "no_execution_surface_introduced"
+      ],
+      "type": "object"
+    },
+    "artifact_id": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "artifact_is_command": {
+      "const": false
+    },
+    "artifact_type": {
+      "const": "GateDescentProposal"
+    },
+    "authority": {
+      "const": false
+    },
+    "connector_mode": {
+      "const": "read_only"
+    },
+    "contract_version": {
+      "const": "eve_q_gate_descent_v0.1"
+    },
+    "created_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "evidence": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence_type": {
+            "enum": [
+              "baseline_soak",
+              "live_read_only_soak",
+              "rollback_test",
+              "threat_model",
+              "contract_lineage",
+              "other"
+            ]
+          },
+          "notes": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "uri": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "evidence_type",
+          "sha256",
+          "uri"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "expires_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "gate_states": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "index": {
+            "maximum": 6,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "name": {
+            "enum": [
+              "SIMULATION_ONLY",
+              "LIVE_READ_ONLY_TELEMETRY",
+              "LIVE_PROPOSAL_GENERATION",
+              "TESTNET_MANUAL_EXTERNAL",
+              "CAPPED_MANUAL_EXTERNAL",
+              "EXECUTION_ASSISTANCE",
+              "NARROW_AUTOMATION"
+            ]
+          },
+          "status": {
+            "enum": [
+              "ACTIVE",
+              "REQUESTED",
+              "LOCKED"
+            ]
+          }
+        },
+        "required": [
+          "index",
+          "name",
+          "status"
+        ],
+        "type": "object"
+      },
+      "maxItems": 7,
+      "minItems": 7,
+      "type": "array"
+    },
+    "human_promotion_required": {
+      "const": true
+    },
+    "may_execute": {
+      "const": false
+    },
+    "may_move_capital": {
+      "const": false
+    },
+    "prohibited_actions": {
+      "items": {
+        "enum": [
+          "wallet_access",
+          "signing",
+          "order_submission",
+          "transaction_construction",
+          "transaction_broadcast",
+          "capital_movement",
+          "self_promotion",
+          "multi_gate_descent"
+        ]
+      },
+      "minItems": 8,
+      "type": "array",
+      "uniqueItems": true
+    },
+    "promotion_eligible": {
+      "type": "boolean"
+    },
+    "readiness": {
+      "enum": [
+        "DRAFT",
+        "READY_FOR_HUMAN_REVIEW"
+      ]
+    },
+    "rollback": {
+      "additionalProperties": false,
+      "properties": {
+        "plan_sha256": {
+          "oneOf": [
+            {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "target_gate": {
+          "const": 0
+        },
+        "test_receipt_sha256": {
+          "oneOf": [
+            {
+              "pattern": "^[0-9a-f]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tested": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "target_gate",
+        "tested",
+        "plan_sha256",
+        "test_receipt_sha256"
+      ],
+      "type": "object"
+    },
+    "transition": {
+      "additionalProperties": false,
+      "properties": {
+        "current_gate": {
+          "const": 0
+        },
+        "downstream_inheritance": {
+          "const": false
+        },
+        "one_gate_only": {
+          "const": true
+        },
+        "requested_gate": {
+          "const": 1
+        }
+      },
+      "required": [
+        "current_gate",
+        "requested_gate",
+        "one_gate_only",
+        "downstream_inheritance"
+      ],
+      "type": "object"
+    },
+    "ttl_seconds": {
+      "maximum": 86400,
+      "minimum": 1,
+      "type": "integer"
+    },
+    "write_capable_secrets_present": {
+      "const": false
+    }
+  },
+  "required": [
+    "artifact_type",
+    "contract_version",
+    "artifact_id",
+    "created_at",
+    "expires_at",
+    "ttl_seconds",
+    "readiness",
+    "promotion_eligible",
+    "transition",
+    "gate_states",
+    "connector_mode",
+    "write_capable_secrets_present",
+    "acceptance_checks",
+    "evidence",
+    "rollback",
+    "prohibited_actions",
+    "artifact_is_command",
+    "authority",
+    "human_promotion_required",
+    "may_execute",
+    "may_move_capital"
+  ],
+  "title": "EVE_Q++ GateDescentProposal v0.1",
+  "type": "object"
+}

--- a/tests/test_gate_descent_v0_1.py
+++ b/tests/test_gate_descent_v0_1.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import copy
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker
+
+from eve_q.gate_descent import (
+    READY_CHECKS,
+    build_gate_0_to_1_draft,
+    refresh_artifact_id,
+    validate_gate_descent,
+)
+
+SCHEMA_PATH = Path("schemas/gate_descent_proposal_v0_1.schema.json")
+EXAMPLE_PATH = Path(
+    "examples/governance/gate_descent_g0_to_g1_draft_v0_1.json"
+)
+NOW = datetime(2026, 7, 11, 21, 5, tzinfo=timezone.utc)
+
+
+def load_example() -> dict:
+    return json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+
+
+def schema_findings(document: dict) -> list:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    return list(
+        Draft202012Validator(
+            schema,
+            format_checker=FormatChecker(),
+        ).iter_errors(document)
+    )
+
+
+def test_draft_example_is_schema_and_semantically_valid():
+    document = load_example()
+
+    assert schema_findings(document) == []
+    assert validate_gate_descent(document, now=NOW) == []
+    assert document["readiness"] == "DRAFT"
+    assert document["promotion_eligible"] is False
+    assert document["gate_states"][0]["status"] == "ACTIVE"
+    assert document["gate_states"][1]["status"] == "REQUESTED"
+    assert all(
+        gate["status"] == "LOCKED"
+        for gate in document["gate_states"][2:]
+    )
+
+
+def test_builder_produces_non_authoritative_adjacent_draft():
+    document = build_gate_0_to_1_draft(
+        created_at="2026-07-11T21:00:00Z",
+        expires_at="2026-07-12T21:00:00Z",
+    )
+
+    assert validate_gate_descent(document, now=NOW) == []
+    assert document["artifact_is_command"] is False
+    assert document["authority"] is False
+    assert document["may_execute"] is False
+    assert document["may_move_capital"] is False
+    assert document["human_promotion_required"] is True
+
+
+def test_skipped_gate_fails_closed():
+    document = load_example()
+    document["transition"]["requested_gate"] = 2
+    document["gate_states"][1]["status"] = "LOCKED"
+    document["gate_states"][2]["status"] = "REQUESTED"
+    document = refresh_artifact_id(document)
+
+    findings = validate_gate_descent(document, now=NOW)
+
+    assert any("Gate 0 -> Gate 1" in finding for finding in findings)
+    assert any("gate_states[1].status" in finding for finding in findings)
+
+
+def test_downstream_gate_cannot_open_early():
+    document = load_example()
+    document["gate_states"][2]["status"] = "ACTIVE"
+    document = refresh_artifact_id(document)
+
+    findings = validate_gate_descent(document, now=NOW)
+
+    assert any(
+        "gate_states[2].status must equal LOCKED" in finding
+        for finding in findings
+    )
+
+
+def test_stale_ttl_fails_closed():
+    document = load_example()
+    document["created_at"] = "2026-07-09T21:00:00Z"
+    document["expires_at"] = "2026-07-10T21:00:00Z"
+    document = refresh_artifact_id(document)
+
+    findings = validate_gate_descent(document, now=NOW)
+
+    assert "gate descent proposal TTL is stale" in findings
+
+
+def test_ready_state_requires_every_check_evidence_and_rollback():
+    document = load_example()
+    document["readiness"] = "READY_FOR_HUMAN_REVIEW"
+    document["promotion_eligible"] = True
+    document = refresh_artifact_id(document)
+
+    findings = validate_gate_descent(document, now=NOW)
+
+    assert any("incomplete acceptance checks" in finding for finding in findings)
+    assert any("missing evidence types" in finding for finding in findings)
+    assert "ready proposal requires a tested rollback" in findings
+
+
+def test_fully_evidenced_ready_state_is_valid_but_still_non_executing():
+    document = load_example()
+    document["readiness"] = "READY_FOR_HUMAN_REVIEW"
+    document["promotion_eligible"] = True
+    document["acceptance_checks"] = {
+        check: True for check in sorted(READY_CHECKS)
+    }
+    document["evidence"].extend(
+        [
+            {
+                "evidence_type": "live_read_only_soak",
+                "sha256": "1" * 64,
+                "uri": "artifact://gate-1/live-read-only-soak",
+            },
+            {
+                "evidence_type": "rollback_test",
+                "sha256": "2" * 64,
+                "uri": "artifact://gate-1/rollback-test",
+            },
+            {
+                "evidence_type": "threat_model",
+                "sha256": "3" * 64,
+                "uri": "artifact://gate-1/threat-model",
+            },
+        ]
+    )
+    document["rollback"] = {
+        "target_gate": 0,
+        "tested": True,
+        "plan_sha256": "4" * 64,
+        "test_receipt_sha256": "5" * 64,
+    }
+    document = refresh_artifact_id(document)
+
+    assert schema_findings(document) == []
+    assert validate_gate_descent(document, now=NOW) == []
+    assert document["authority"] is False
+    assert document["may_execute"] is False
+    assert document["may_move_capital"] is False
+
+
+def test_authority_leakage_fails_schema_and_semantics():
+    document = load_example()
+    document["authority"] = True
+    document["may_execute"] = True
+    document = refresh_artifact_id(document)
+
+    assert schema_findings(document)
+    findings = validate_gate_descent(document, now=NOW)
+    assert "authority must be false" in findings
+    assert "may_execute must be false" in findings
+
+
+def test_canonical_artifact_id_detects_mutation():
+    document = load_example()
+    mutated = copy.deepcopy(document)
+    mutated["connector_mode"] = "write_capable"
+
+    findings = validate_gate_descent(mutated, now=NOW)
+
+    assert "artifact_id does not match canonical payload hash" in findings
+    assert "connector_mode must be read_only" in findings


### PR DESCRIPTION
## Summary

Implements issue #66 by encoding the one-gate-at-a-time capability-release law for EVE_Q++.

## Adds

- a seven-stage capability ladder from simulation-only through future narrow automation;
- a `GateDescentProposal` JSON Schema;
- a canonical-hash builder and semantic validator;
- an explicit Gate 0 → Gate 1 draft fixture;
- fail-closed checks for skipped gates, downstream leakage, stale TTL, incomplete evidence, untested rollback, write-capable connectors/secrets, authority leakage, execution leakage, and capital leakage;
- Python 3.11/3.13 CI;
- governance documentation and CLI examples.

## v0.1 boundary

This PR does **not** lower Gate 1.

It encodes the only eligible transition as:

```text
Gate 0 SIMULATION_ONLY: ACTIVE
Gate 1 LIVE_READ_ONLY_TELEMETRY: REQUESTED
Gate 2–6: LOCKED
```

A proposal can become `READY_FOR_HUMAN_REVIEW` only after all acceptance checks are true and content-addressed evidence exists for:

- the simulation baseline soak;
- a live-read-only soak;
- a rollback test;
- a threat model.

Even then, the artifact remains:

```json
{
  "artifact_is_command": false,
  "authority": false,
  "human_promotion_required": true,
  "may_execute": false,
  "may_move_capital": false
}
```

## Core law

```text
lower one gate
→ keep every downstream gate closed
→ observe
→ perturb
→ audit
→ prove rollback
→ earn the next gate
```

Closes #66 after tests and review are complete.

Always forward.