### PR TITLE
Gate 1 synthetic failure campaign v0.1

### DIFF
--- a/.github/workflows/eve-q-gate1-failure-campaign-ci.yml
+++ b/.github/workflows/eve-q-gate1-failure-campaign-ci.yml
@@ -1,0 +1,90 @@
+name: EVE_Q++ Gate 1 Failure Campaign CI
+
+on:
+  pull_request:
+    paths:
+      - "eve_q/gate1_failure_campaign.py"
+      - "scripts/run_gate1_failure_campaign_v0_1.sh"
+      - "tests/test_gate1_failure_campaign_v0_1.py"
+      - "docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_v0_1.md"
+      - "docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_ACCEPTANCE_v0_1.json"
+      - ".github/workflows/eve-q-gate1-failure-campaign-ci.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "eve_q/gate1_failure_campaign.py"
+      - "scripts/run_gate1_failure_campaign_v0_1.sh"
+      - "tests/test_gate1_failure_campaign_v0_1.py"
+      - "docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_v0_1.md"
+      - "docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_ACCEPTANCE_v0_1.json"
+      - ".github/workflows/eve-q-gate1-failure-campaign-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  failure-campaign:
+    name: Synthetic failure campaign (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install development dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Compile and syntax check
+        run: |
+          python -m py_compile eve_q/gate1_failure_campaign.py
+          bash -n scripts/run_gate1_failure_campaign_v0_1.sh
+
+      - name: Run focused tests
+        run: |
+          python -m pytest -q --no-cov \
+            tests/test_gate1_failure_campaign_v0_1.py
+
+      - name: Run deterministic 100-cycle campaign
+        env:
+          CYCLES: "100"
+          SEED: "424243"
+          PRODUCER_COMMIT: ${{ github.sha }}
+          RUN_ROOT: ${{ runner.temp }}/spiralbloom-runs
+          RUN_ID: gate1-failure-ci
+        run: |
+          bash scripts/run_gate1_failure_campaign_v0_1.sh
+
+      - name: Verify acceptance contract remains non-authoritative
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          contract = json.loads(
+              Path(
+                  "docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_ACCEPTANCE_v0_1.json"
+              ).read_text(encoding="utf-8")
+          )
+
+          assert contract["network_calls_permitted"] is False
+          assert contract["artifact_is_command"] is False
+          assert contract["authority"] is False
+          assert contract["human_promotion_required"] is True
+          assert contract["may_generate_live_proposal"] is False
+          assert contract["may_execute"] is False
+          assert contract["may_move_capital"] is False
+          assert contract["gate_posture"]["gate_2_through_6"] == "LOCKED"
+          PY

--- a/docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_ACCEPTANCE_v0_1.json
+++ b/docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_ACCEPTANCE_v0_1.json
@@ -1,0 +1,42 @@
+{
+  "artifact_type": "Gate1FailureCampaignAcceptance",
+  "contract_version": "eve_q_gate1_failure_campaign_v0.1",
+  "required_cases": [
+    "independent_agreement",
+    "conflicting_sources",
+    "weak_provenance_agreement",
+    "source_outage",
+    "stale_snapshot",
+    "malformed_payload",
+    "replay_hash_mismatch",
+    "non_public_dns",
+    "dns_address_drift"
+  ],
+  "required_acceptance": {
+    "all_cases_exercised": true,
+    "all_cases_passed": true,
+    "zero_unexpected_failures": true,
+    "zero_unauthorized_transitions": true,
+    "outage_rollback_proven": true,
+    "conflict_holds": true,
+    "herding_risk_holds": true,
+    "independent_agreement_observation_only": true,
+    "stale_rejected": true,
+    "malformed_rejected": true,
+    "tamper_rejected": true,
+    "non_public_dns_rejected": true,
+    "dns_drift_rejected": true
+  },
+  "network_calls_permitted": false,
+  "artifact_is_command": false,
+  "authority": false,
+  "human_promotion_required": true,
+  "may_generate_live_proposal": false,
+  "may_execute": false,
+  "may_move_capital": false,
+  "gate_posture": {
+    "gate_0": "ACTIVE",
+    "gate_1": "PILOT_ONLY",
+    "gate_2_through_6": "LOCKED"
+  }
+}

--- a/docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_v0_1.md
+++ b/docs/testing/EVE_Q_GATE1_FAILURE_CAMPAIGN_v0_1.md
@@ -1,0 +1,79 @@
+# EVE_Q++ Gate 1 Synthetic Failure Campaign v0.1
+
+## Purpose
+
+This campaign disturbs the Gate 1 read-only observation membrane without contacting a live source. It produces deterministic evidence that source failures and epistemic disagreement cannot cascade into proposal generation, execution authority, or capital authority.
+
+## Cases
+
+| Case | Required result |
+|---|---|
+| Independent agreement | `GROUNDED` + `OBSERVE_ONLY` |
+| Conflicting sources | `CONFLICTING` + `HOLD` |
+| Weak-provenance agreement | `HERDING_RISK` + `HOLD` |
+| Source outage | valid rollback receipt to Gate 0 |
+| Stale snapshot | rejected |
+| Malformed payload | rejected |
+| Replay hash mismatch | rejected |
+| Non-public DNS answer | rejected |
+| DNS address-set drift | rejected |
+
+Agreement never creates authority. Even independently corroborated observations remain observation-only.
+
+## Boundary
+
+Every campaign record preserves:
+
+```json
+{
+  "artifact_is_command": false,
+  "authority": false,
+  "human_promotion_required": true,
+  "may_generate_live_proposal": false,
+  "may_execute": false,
+  "may_move_capital": false,
+  "gate_posture": {
+    "gate_0": "ACTIVE",
+    "gate_1": "PILOT_ONLY",
+    "gate_2_through_6": "LOCKED"
+  }
+}
+```
+
+The campaign performs no network calls and configures no live source.
+
+## Run
+
+```bash
+export CYCLES=100
+export SEED=424243
+export PRODUCER_COMMIT="$(git rev-parse HEAD)"
+
+bash scripts/run_gate1_failure_campaign_v0_1.sh
+```
+
+Outputs:
+
+```text
+$HOME/spiralbloom-runs/<run-id>/campaign.jsonl
+$HOME/spiralbloom-runs/<run-id>/summary.json
+```
+
+## Acceptance
+
+A passing campaign requires:
+
+- every case exercised;
+- every case producing the expected fail-closed disposition;
+- zero unexpected failures;
+- zero unauthorized transitions;
+- every outage producing a canonical rollback artifact;
+- conflict and herding risk always producing `HOLD`;
+- independent agreement remaining `OBSERVE_ONLY`;
+- Gate 2–6 remaining locked.
+
+## Interpretation
+
+This is synthetic resilience evidence. It does not activate Gate 1, prove live-source reliability, or authorize live proposal generation.
+
+> Observe disagreement. Preserve uncertainty. Roll back cleanly. Never promote by momentum.

--- a/eve_q/gate1_failure_campaign.py
+++ b/eve_q/gate1_failure_campaign.py
@@ -1,0 +1,600 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import random
+import socket
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+from eve_q.gate1_hardening import (
+    Gate1HardeningError,
+    build_resolution_receipt,
+    build_rollback_receipt,
+    validate_resolution_receipt,
+    validate_rollback_receipt,
+)
+from eve_q.live_read_only_telemetry import (
+    SourceSpec,
+    TelemetryBoundaryError,
+    TransportResult,
+    build_snapshot,
+    canonical_json_bytes,
+    iso_z,
+    sha256_hex,
+    validate_snapshot,
+)
+
+CONTRACT_VERSION = "eve_q_gate1_failure_campaign_v0.1"
+ARTIFACT_TYPE = "Gate1FailureCampaignSummary"
+DEFAULT_CYCLES = 100
+DEFAULT_SEED = 424243
+
+CASE_NAMES: tuple[str, ...] = (
+    "independent_agreement",
+    "conflicting_sources",
+    "weak_provenance_agreement",
+    "source_outage",
+    "stale_snapshot",
+    "malformed_payload",
+    "replay_hash_mismatch",
+    "non_public_dns",
+    "dns_address_drift",
+)
+
+NON_AUTHORITY = {
+    "artifact_is_command": False,
+    "authority": False,
+    "human_promotion_required": True,
+    "may_generate_live_proposal": False,
+    "may_execute": False,
+    "may_move_capital": False,
+}
+
+
+@dataclass(frozen=True)
+class CoalitionObservation:
+    source_id: str
+    provenance_group: str
+    normalized_sha256: str
+
+
+@dataclass(frozen=True)
+class CoalitionDecision:
+    evidence_state: str
+    disposition: str
+    reason: str
+
+
+Resolver = Callable[..., Iterable[tuple[Any, ...]]]
+
+
+def canonical_sha256(document: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(document)).hexdigest()
+
+
+def classify_coalition(
+    observations: Sequence[CoalitionObservation],
+) -> CoalitionDecision:
+    """Classify source agreement without granting authority.
+
+    Agreement is not truth. Independent corroboration can become GROUNDED
+    observation evidence, but never a proposal or execution command.
+    """
+    if len(observations) < 2:
+        return CoalitionDecision(
+            evidence_state="INSUFFICIENT",
+            disposition="HOLD",
+            reason="fewer than two observations",
+        )
+
+    payload_hashes = {item.normalized_sha256 for item in observations}
+    provenance_groups = {item.provenance_group for item in observations}
+
+    if len(payload_hashes) > 1:
+        return CoalitionDecision(
+            evidence_state="CONFLICTING",
+            disposition="HOLD",
+            reason="independent observations disagree",
+        )
+
+    if len(provenance_groups) < 2:
+        return CoalitionDecision(
+            evidence_state="HERDING_RISK",
+            disposition="HOLD",
+            reason="agreement lacks provenance independence",
+        )
+
+    return CoalitionDecision(
+        evidence_state="GROUNDED",
+        disposition="OBSERVE_ONLY",
+        reason="matching observations have independent provenance",
+    )
+
+
+def _spec(
+    source_id: str,
+    host: str,
+    *,
+    ttl_seconds: int = 300,
+) -> SourceSpec:
+    return SourceSpec(
+        source_id=source_id,
+        source_kind="market_snapshot",
+        url=f"https://{host}/v1/market",
+        allowed_hosts=(host,),
+        freshness_ttl_seconds=ttl_seconds,
+        timeout_seconds=5.0,
+        max_response_bytes=4096,
+    )
+
+
+def _result(
+    *,
+    body: bytes,
+    host: str,
+    retrieved_at: str,
+    content_type: str = "application/json; charset=utf-8",
+) -> TransportResult:
+    return TransportResult(
+        status=200,
+        headers={"Content-Type": content_type},
+        body=body,
+        final_url=f"https://{host}/v1/market",
+        retrieved_at=retrieved_at,
+    )
+
+
+def _resolver_for(*addresses: str) -> Resolver:
+    def resolver(
+        host: str,
+        port: int,
+        *,
+        family: int,
+        type: int,
+        proto: int,
+    ) -> list[tuple[Any, ...]]:
+        del host, family
+        records: list[tuple[Any, ...]] = []
+        for address in addresses:
+            socket_family = socket.AF_INET6 if ":" in address else socket.AF_INET
+            sockaddr: tuple[Any, ...]
+            if socket_family == socket.AF_INET6:
+                sockaddr = (address, port, 0, 0)
+            else:
+                sockaddr = (address, port)
+            records.append((socket_family, type, proto, "", sockaddr))
+        return records
+
+    return resolver
+
+
+def _authority_fields() -> dict[str, bool]:
+    return dict(NON_AUTHORITY)
+
+
+def _base_record(index: int, case_name: str) -> dict[str, Any]:
+    return {
+        "cycle_index": index,
+        "case": case_name,
+        "passed": False,
+        "evidence_state": "UNRESOLVED",
+        "disposition": "HOLD",
+        "reason": "not evaluated",
+        "rollback_artifact_id": None,
+        **_authority_fields(),
+        "gate_posture": {
+            "gate_0": "ACTIVE",
+            "gate_1": "PILOT_ONLY",
+            "gate_2_through_6": "LOCKED",
+        },
+    }
+
+
+def _payload(value: str, source: str) -> bytes:
+    return canonical_json_bytes({"price": value, "source": source})
+
+
+def run_case(
+    case_name: str,
+    *,
+    index: int,
+    producer_commit: str,
+    observed_at: datetime,
+    rng: random.Random,
+) -> dict[str, Any]:
+    record = _base_record(index, case_name)
+    observed_text = iso_z(observed_at)
+    price = f"{100 + rng.randrange(0, 5000) / 100:.2f}"
+
+    try:
+        if case_name == "independent_agreement":
+            digest = sha256_hex(_payload(price, "normalized"))
+            decision = classify_coalition(
+                (
+                    CoalitionObservation("source-a", "provider-a", digest),
+                    CoalitionObservation("source-b", "provider-b", digest),
+                )
+            )
+            record.update(
+                passed=(
+                    decision.evidence_state == "GROUNDED"
+                    and decision.disposition == "OBSERVE_ONLY"
+                ),
+                evidence_state=decision.evidence_state,
+                disposition=decision.disposition,
+                reason=decision.reason,
+            )
+
+        elif case_name == "conflicting_sources":
+            first = sha256_hex(_payload(price, "source-a"))
+            second_price = f"{float(price) + 1.0:.2f}"
+            second = sha256_hex(_payload(second_price, "source-b"))
+            decision = classify_coalition(
+                (
+                    CoalitionObservation("source-a", "provider-a", first),
+                    CoalitionObservation("source-b", "provider-b", second),
+                )
+            )
+            record.update(
+                passed=(
+                    decision.evidence_state == "CONFLICTING"
+                    and decision.disposition == "HOLD"
+                ),
+                evidence_state=decision.evidence_state,
+                disposition=decision.disposition,
+                reason=decision.reason,
+            )
+
+        elif case_name == "weak_provenance_agreement":
+            digest = sha256_hex(_payload(price, "shared-upstream"))
+            decision = classify_coalition(
+                (
+                    CoalitionObservation("mirror-a", "shared-provider", digest),
+                    CoalitionObservation("mirror-b", "shared-provider", digest),
+                )
+            )
+            record.update(
+                passed=(
+                    decision.evidence_state == "HERDING_RISK"
+                    and decision.disposition == "HOLD"
+                ),
+                evidence_state=decision.evidence_state,
+                disposition=decision.disposition,
+                reason=decision.reason,
+            )
+
+        elif case_name == "source_outage":
+            rollback = build_rollback_receipt(
+                producer_commit=producer_commit,
+                trigger="source_outage",
+                started_at=observed_text,
+                completed_at=observed_text,
+            )
+            findings = validate_rollback_receipt(rollback)
+            record.update(
+                passed=(findings == []),
+                evidence_state="SOURCE_OUTAGE",
+                disposition="ROLLBACK_TO_GATE_0",
+                reason="source outage produced a valid rollback receipt",
+                rollback_artifact_id=rollback["artifact_id"],
+            )
+
+        elif case_name == "stale_snapshot":
+            spec = _spec("stale-source", "stale.example.test", ttl_seconds=30)
+            document, raw_bytes, normalized_bytes = build_snapshot(
+                spec,
+                _result(
+                    body=_payload(price, "stale-source"),
+                    host="stale.example.test",
+                    retrieved_at=observed_text,
+                ),
+                producer_commit=producer_commit,
+            )
+            findings = validate_snapshot(
+                document,
+                raw_bytes,
+                normalized_bytes,
+                now=observed_at + timedelta(seconds=31),
+            )
+            record.update(
+                passed=("telemetry snapshot is stale" in findings),
+                evidence_state="STALE",
+                disposition="REJECT",
+                reason="stale snapshot rejected",
+            )
+
+        elif case_name == "malformed_payload":
+            spec = _spec("malformed-source", "malformed.example.test")
+            try:
+                build_snapshot(
+                    spec,
+                    _result(
+                        body=b"not-json",
+                        host="malformed.example.test",
+                        retrieved_at=observed_text,
+                    ),
+                    producer_commit=producer_commit,
+                )
+            except TelemetryBoundaryError as exc:
+                passed = exc.code == "malformed_json"
+                reason = exc.code
+            else:
+                passed = False
+                reason = "malformed payload was accepted"
+            record.update(
+                passed=passed,
+                evidence_state="MALFORMED",
+                disposition="REJECT",
+                reason=reason,
+            )
+
+        elif case_name == "replay_hash_mismatch":
+            spec = _spec("tamper-source", "tamper.example.test")
+            document, raw_bytes, normalized_bytes = build_snapshot(
+                spec,
+                _result(
+                    body=_payload(price, "tamper-source"),
+                    host="tamper.example.test",
+                    retrieved_at=observed_text,
+                ),
+                producer_commit=producer_commit,
+            )
+            findings = validate_snapshot(
+                document,
+                raw_bytes + b"tampered",
+                normalized_bytes,
+                now=observed_at,
+            )
+            record.update(
+                passed=("raw payload hash mismatch" in findings),
+                evidence_state="TAMPERED",
+                disposition="REJECT",
+                reason="replay hash mismatch rejected",
+            )
+
+        elif case_name == "non_public_dns":
+            spec = _spec("private-dns", "private-dns.example.test")
+            try:
+                build_resolution_receipt(
+                    spec,
+                    producer_commit=producer_commit,
+                    created_at=observed_text,
+                    resolver=_resolver_for("127.0.0.1"),
+                )
+            except Gate1HardeningError as exc:
+                passed = exc.code == "non_public_address_rejected"
+                reason = exc.code
+            else:
+                passed = False
+                reason = "non-public DNS answer was accepted"
+            record.update(
+                passed=passed,
+                evidence_state="DNS_POLICY_FAILURE",
+                disposition="REJECT",
+                reason=reason,
+            )
+
+        elif case_name == "dns_address_drift":
+            spec = _spec("drift-source", "drift.example.test")
+            receipt = build_resolution_receipt(
+                spec,
+                producer_commit=producer_commit,
+                created_at=observed_text,
+                resolver=_resolver_for("8.8.8.8"),
+            )
+            findings = validate_resolution_receipt(
+                receipt,
+                current_spec=spec,
+                resolver=_resolver_for("1.1.1.1"),
+            )
+            record.update(
+                passed=any(
+                    "DNS resolution changed" in finding for finding in findings
+                ),
+                evidence_state="DNS_DRIFT",
+                disposition="REJECT_AND_ROLLBACK",
+                reason="postflight address-set drift rejected",
+            )
+
+        else:
+            raise ValueError(f"unsupported campaign case: {case_name}")
+
+    except Exception as exc:  # campaign records unexpected failures, then fails closed
+        record.update(
+            passed=False,
+            evidence_state="INTERNAL_FAILURE",
+            disposition="ROLLBACK_TO_GATE_0",
+            reason=f"{type(exc).__name__}: {exc}",
+        )
+
+    record["record_sha256"] = canonical_sha256(
+        {key: value for key, value in record.items() if key != "record_sha256"}
+    )
+    return record
+
+
+def build_case_schedule(cycles: int, seed: int) -> list[str]:
+    if cycles < len(CASE_NAMES):
+        raise ValueError(f"cycles must be at least {len(CASE_NAMES)}")
+    rng = random.Random(seed)
+    schedule: list[str] = []
+    while len(schedule) < cycles:
+        block = list(CASE_NAMES)
+        rng.shuffle(block)
+        schedule.extend(block)
+    return schedule[:cycles]
+
+
+def generate_records(
+    *,
+    cycles: int,
+    seed: int,
+    producer_commit: str,
+) -> list[dict[str, Any]]:
+    if len(producer_commit) != 40 or any(
+        character not in "0123456789abcdef" for character in producer_commit.lower()
+    ):
+        raise ValueError("producer_commit must be a 40-character hexadecimal SHA")
+
+    schedule = build_case_schedule(cycles, seed)
+    rng = random.Random(seed)
+    epoch = datetime(2026, 7, 11, 22, 30, tzinfo=timezone.utc)
+    return [
+        run_case(
+            case_name,
+            index=index,
+            producer_commit=producer_commit.lower(),
+            observed_at=epoch + timedelta(seconds=index),
+            rng=rng,
+        )
+        for index, case_name in enumerate(schedule)
+    ]
+
+
+def build_summary(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    cycles: int,
+    seed: int,
+    producer_commit: str,
+) -> dict[str, Any]:
+    case_counts = {name: 0 for name in CASE_NAMES}
+    case_passes = {name: 0 for name in CASE_NAMES}
+    for record in records:
+        case_name = str(record["case"])
+        case_counts[case_name] += 1
+        if record.get("passed") is True:
+            case_passes[case_name] += 1
+
+    failures = sum(record.get("passed") is not True for record in records)
+    unauthorized = sum(
+        bool(record.get("authority"))
+        or bool(record.get("may_generate_live_proposal"))
+        or bool(record.get("may_execute"))
+        or bool(record.get("may_move_capital"))
+        for record in records
+    )
+    rollback_count = sum(
+        record.get("disposition") == "ROLLBACK_TO_GATE_0"
+        for record in records
+    )
+    ledger_sha256 = canonical_sha256(list(records))
+
+    acceptance = {
+        "all_cases_exercised": all(case_counts.values()),
+        "all_cases_passed": all(
+            case_passes[name] == case_counts[name] for name in CASE_NAMES
+        ),
+        "zero_unexpected_failures": failures == 0,
+        "zero_unauthorized_transitions": unauthorized == 0,
+        "outage_rollback_proven": case_passes["source_outage"] > 0,
+        "conflict_holds": case_passes["conflicting_sources"] > 0,
+        "herding_risk_holds": case_passes["weak_provenance_agreement"] > 0,
+        "independent_agreement_observation_only": (
+            case_passes["independent_agreement"] > 0
+        ),
+        "stale_rejected": case_passes["stale_snapshot"] > 0,
+        "malformed_rejected": case_passes["malformed_payload"] > 0,
+        "tamper_rejected": case_passes["replay_hash_mismatch"] > 0,
+        "non_public_dns_rejected": case_passes["non_public_dns"] > 0,
+        "dns_drift_rejected": case_passes["dns_address_drift"] > 0,
+    }
+
+    summary: dict[str, Any] = {
+        "artifact_type": ARTIFACT_TYPE,
+        "contract_version": CONTRACT_VERSION,
+        "campaign": {
+            "cycles_requested": cycles,
+            "seed": seed,
+            "producer_commit": producer_commit.lower(),
+            "network_calls_permitted": False,
+        },
+        "results": {
+            "records": len(records),
+            "failures": failures,
+            "unauthorized_transitions": unauthorized,
+            "rollback_count": rollback_count,
+            "case_counts": case_counts,
+            "case_passes": case_passes,
+            "ledger_sha256": ledger_sha256,
+        },
+        "acceptance": acceptance,
+        "ok": all(acceptance.values()),
+        **_authority_fields(),
+        "gate_posture": {
+            "gate_0": "ACTIVE",
+            "gate_1": "PILOT_ONLY",
+            "gate_2_through_6": "LOCKED",
+        },
+    }
+    summary["artifact_id"] = canonical_sha256(summary)
+    return summary
+
+
+def run_campaign(
+    output_dir: Path,
+    *,
+    cycles: int = DEFAULT_CYCLES,
+    seed: int = DEFAULT_SEED,
+    producer_commit: str,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=False)
+    records = generate_records(
+        cycles=cycles,
+        seed=seed,
+        producer_commit=producer_commit,
+    )
+    summary = build_summary(
+        records,
+        cycles=cycles,
+        seed=seed,
+        producer_commit=producer_commit,
+    )
+
+    ledger_path = output_dir / "campaign.jsonl"
+    ledger_path.write_text(
+        "".join(
+            json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+            for record in records
+        ),
+        encoding="utf-8",
+    )
+    summary_path = output_dir / "summary.json"
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run the deterministic Gate 1 synthetic failure campaign."
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--cycles", type=int, default=DEFAULT_CYCLES)
+    parser.add_argument("--seed", type=int, default=DEFAULT_SEED)
+    parser.add_argument("--producer-commit", required=True)
+    args = parser.parse_args()
+
+    summary = run_campaign(
+        args.output_dir,
+        cycles=args.cycles,
+        seed=args.seed,
+        producer_commit=args.producer_commit,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    if not summary["ok"]:
+        return 1
+    print("Gate 1 synthetic failure campaign: PASS")
+    print(f"Summary: {args.output_dir / 'summary.json'}")
+    print(f"Ledger: {args.output_dir / 'campaign.jsonl'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_gate1_failure_campaign_v0_1.sh
+++ b/scripts/run_gate1_failure_campaign_v0_1.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CYCLES:=100}"
+: "${SEED:=424243}"
+: "${RUN_ROOT:=$HOME/spiralbloom-runs}"
+: "${RUN_ID:=gate1-failure-campaign-$(date -u +%Y%m%dT%H%M%SZ)}"
+: "${PRODUCER_COMMIT:=$(git rev-parse HEAD)}"
+
+OUT="$RUN_ROOT/$RUN_ID"
+
+python -m eve_q.gate1_failure_campaign \
+  --output-dir "$OUT" \
+  --cycles "$CYCLES" \
+  --seed "$SEED" \
+  --producer-commit "$PRODUCER_COMMIT"
+
+python - "$OUT/summary.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+
+assert summary["ok"] is True
+assert summary["results"]["failures"] == 0
+assert summary["results"]["unauthorized_transitions"] == 0
+assert summary["acceptance"]["conflict_holds"] is True
+assert summary["acceptance"]["herding_risk_holds"] is True
+assert summary["acceptance"]["outage_rollback_proven"] is True
+assert summary["acceptance"]["independent_agreement_observation_only"] is True
+assert summary["authority"] is False
+assert summary["may_generate_live_proposal"] is False
+assert summary["may_execute"] is False
+assert summary["may_move_capital"] is False
+assert summary["gate_posture"]["gate_2_through_6"] == "LOCKED"
+
+print("Gate 1 failure campaign launcher: PASS")
+PY
+
+printf 'Run ID: %s\n' "$RUN_ID"
+printf 'Summary: %s\n' "$OUT/summary.json"
+printf 'Ledger: %s\n' "$OUT/campaign.jsonl"

--- a/tests/test_gate1_failure_campaign_v0_1.py
+++ b/tests/test_gate1_failure_campaign_v0_1.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from eve_q.gate1_failure_campaign import (
+    CASE_NAMES,
+    CoalitionObservation,
+    build_summary,
+    classify_coalition,
+    generate_records,
+    run_campaign,
+)
+
+PRODUCER_COMMIT = "a" * 40
+
+
+def test_coalition_classifier_separates_grounded_conflict_and_herding():
+    same = "1" * 64
+    different = "2" * 64
+
+    grounded = classify_coalition(
+        (
+            CoalitionObservation("a", "provider-a", same),
+            CoalitionObservation("b", "provider-b", same),
+        )
+    )
+    assert grounded.evidence_state == "GROUNDED"
+    assert grounded.disposition == "OBSERVE_ONLY"
+
+    conflict = classify_coalition(
+        (
+            CoalitionObservation("a", "provider-a", same),
+            CoalitionObservation("b", "provider-b", different),
+        )
+    )
+    assert conflict.evidence_state == "CONFLICTING"
+    assert conflict.disposition == "HOLD"
+
+    herding = classify_coalition(
+        (
+            CoalitionObservation("a", "shared-provider", same),
+            CoalitionObservation("b", "shared-provider", same),
+        )
+    )
+    assert herding.evidence_state == "HERDING_RISK"
+    assert herding.disposition == "HOLD"
+
+
+def test_seeded_records_are_deterministic_and_exercise_every_case():
+    first = generate_records(
+        cycles=100,
+        seed=424243,
+        producer_commit=PRODUCER_COMMIT,
+    )
+    second = generate_records(
+        cycles=100,
+        seed=424243,
+        producer_commit=PRODUCER_COMMIT,
+    )
+
+    assert first == second
+    assert {record["case"] for record in first} == set(CASE_NAMES)
+    assert all(record["passed"] is True for record in first)
+
+
+def test_campaign_preserves_authority_boundary_and_locked_gates():
+    records = generate_records(
+        cycles=90,
+        seed=7,
+        producer_commit=PRODUCER_COMMIT,
+    )
+
+    for record in records:
+        assert record["artifact_is_command"] is False
+        assert record["authority"] is False
+        assert record["human_promotion_required"] is True
+        assert record["may_generate_live_proposal"] is False
+        assert record["may_execute"] is False
+        assert record["may_move_capital"] is False
+        assert record["gate_posture"] == {
+            "gate_0": "ACTIVE",
+            "gate_1": "PILOT_ONLY",
+            "gate_2_through_6": "LOCKED",
+        }
+
+
+def test_summary_requires_every_case_and_zero_unauthorized_transitions():
+    records = generate_records(
+        cycles=99,
+        seed=11,
+        producer_commit=PRODUCER_COMMIT,
+    )
+    summary = build_summary(
+        records,
+        cycles=99,
+        seed=11,
+        producer_commit=PRODUCER_COMMIT,
+    )
+
+    assert summary["ok"] is True
+    assert summary["results"]["failures"] == 0
+    assert summary["results"]["unauthorized_transitions"] == 0
+    assert summary["acceptance"]["conflict_holds"] is True
+    assert summary["acceptance"]["herding_risk_holds"] is True
+    assert summary["acceptance"]["outage_rollback_proven"] is True
+    assert summary["acceptance"]["independent_agreement_observation_only"] is True
+
+
+def test_run_campaign_writes_inspectable_ledger_and_summary(tmp_path: Path):
+    output_dir = tmp_path / "campaign"
+    summary = run_campaign(
+        output_dir,
+        cycles=100,
+        seed=424243,
+        producer_commit=PRODUCER_COMMIT,
+    )
+
+    summary_path = output_dir / "summary.json"
+    ledger_path = output_dir / "campaign.jsonl"
+
+    assert summary["ok"] is True
+    assert summary_path.is_file()
+    assert ledger_path.is_file()
+
+    persisted = json.loads(summary_path.read_text(encoding="utf-8"))
+    ledger = [
+        json.loads(line)
+        for line in ledger_path.read_text(encoding="utf-8").splitlines()
+    ]
+
+    assert persisted == summary
+    assert len(ledger) == 100
+    assert all(record["record_sha256"] for record in ledger)
+
+
+def test_source_outage_always_produces_valid_gate0_rollback_evidence():
+    records = generate_records(
+        cycles=90,
+        seed=13,
+        producer_commit=PRODUCER_COMMIT,
+    )
+    outages = [record for record in records if record["case"] == "source_outage"]
+
+    assert outages
+    assert all(record["passed"] is True for record in outages)
+    assert all(record["disposition"] == "ROLLBACK_TO_GATE_0" for record in outages)
+    assert all(record["rollback_artifact_id"] for record in outages)
+
+
+def test_too_few_cycles_fail_before_campaign_execution():
+    try:
+        generate_records(
+            cycles=len(CASE_NAMES) - 1,
+            seed=1,
+            producer_commit=PRODUCER_COMMIT,
+        )
+    except ValueError as exc:
+        assert "cycles must be at least" in str(exc)
+    else:
+        raise AssertionError("campaign accepted too few cycles")


### PR DESCRIPTION
## Summary

Implements issue #72 with a deterministic, network-free campaign against the Gate 1 read-only observation membrane.

## Campaign cases

- independent-source agreement → `GROUNDED`, `OBSERVE_ONLY`;
- conflicting independent sources → `CONFLICTING`, `HOLD`;
- same-upstream agreement → `HERDING_RISK`, `HOLD`;
- source outage → canonical rollback receipt to Gate 0;
- stale snapshot → rejected;
- malformed payload → rejected;
- replay hash mismatch → rejected;
- non-public DNS answer → rejected;
- DNS address-set drift → rejected.

## Outputs

- deterministic JSONL campaign ledger;
- canonical summary receipt;
- per-record canonical hashes;
- seeded 100-cycle launcher;
- machine-readable acceptance contract;
- Python 3.11/3.13 CI.

## Authority boundary

```json
{
  "network_calls_permitted": false,
  "artifact_is_command": false,
  "authority": false,
  "human_promotion_required": true,
  "may_generate_live_proposal": false,
  "may_execute": false,
  "may_move_capital": false
}
```

Gate 0 remains active, Gate 1 remains pilot-only, and Gate 2–6 remain locked.

This PR does not configure a live source or activate Gate 1.

Closes #72 after the campaign passes locally and in CI.

Always forward.