### PR TITLE
Build Gate 1 source review artifact v0.1

### DIFF
--- a/.github/workflows/gate1-source-review-artifact-v0-1-ci.yml
+++ b/.github/workflows/gate1-source-review-artifact-v0-1-ci.yml
@@ -1,0 +1,141 @@
+name: Gate 1 Source Review Artifact v0.1 CI
+
+on:
+  pull_request:
+    paths:
+      - "eve_q/gate1_source_review.py"
+      - "schemas/gate1_source_review_artifact_v0_1.schema.json"
+      - "examples/telemetry/source_review_candidate_template_v0_1.json"
+      - "docs/telemetry/EVE_Q_GATE1_SOURCE_REVIEW_ARTIFACT_v0_1.md"
+      - "docs/testing/EVE_Q_GATE1_SOURCE_REVIEW_ACCEPTANCE_v0_1.json"
+      - "tests/test_gate1_source_review_artifact_v0_1.py"
+      - ".github/workflows/gate1-source-review-artifact-v0-1-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "eve_q/gate1_source_review.py"
+      - "schemas/gate1_source_review_artifact_v0_1.schema.json"
+      - "examples/telemetry/source_review_candidate_template_v0_1.json"
+      - "docs/telemetry/EVE_Q_GATE1_SOURCE_REVIEW_ARTIFACT_v0_1.md"
+      - "docs/testing/EVE_Q_GATE1_SOURCE_REVIEW_ACCEPTANCE_v0_1.json"
+      - "tests/test_gate1_source_review_artifact_v0_1.py"
+      - ".github/workflows/gate1-source-review-artifact-v0-1-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  source-review:
+    name: Source review artifact (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install validation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: Compile source-review module
+        run: |
+          python -m py_compile eve_q/gate1_source_review.py
+
+      - name: Run source-review contract tests
+        run: |
+          python -m pytest -q -o addopts='' \
+            tests/test_gate1_source_review_artifact_v0_1.py
+
+      - name: Prove deterministic template replay
+        run: |
+          set -euo pipefail
+          RUN_A="$(mktemp -d)"
+          RUN_B="$(mktemp -d)"
+          COMMIT="$(git rev-parse HEAD)"
+          CREATED_AT="2026-07-12T01:00:00Z"
+
+          python -m eve_q.gate1_source_review build \
+            --candidate examples/telemetry/source_review_candidate_template_v0_1.json \
+            --producer-commit "$COMMIT" \
+            --created-at "$CREATED_AT" \
+            --output "$RUN_A/artifact.json" \
+            > "$RUN_A/stdout.json"
+
+          python -m eve_q.gate1_source_review build \
+            --candidate examples/telemetry/source_review_candidate_template_v0_1.json \
+            --producer-commit "$COMMIT" \
+            --created-at "$CREATED_AT" \
+            --output "$RUN_B/artifact.json" \
+            > "$RUN_B/stdout.json"
+
+          cmp "$RUN_A/artifact.json" "$RUN_B/artifact.json"
+          cmp "$RUN_A/stdout.json" "$RUN_B/stdout.json"
+
+          python -m eve_q.gate1_source_review verify \
+            --artifact "$RUN_A/artifact.json"
+
+          python - "$RUN_A/artifact.json" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          artifact = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          assert artifact["review"]["observation_eligibility"] == "HOLD"
+          assert artifact["gate_posture"] == {
+              "gate_0": "ACTIVE",
+              "gate_1": "PILOT_ONLY",
+              "gate_2_through_6": "LOCKED",
+          }
+          assert artifact["artifact_is_command"] is False
+          assert artifact["authority"] is False
+          assert artifact["may_activate_gate_1"] is False
+          assert artifact["may_generate_live_proposal"] is False
+          assert artifact["may_execute"] is False
+          assert artifact["may_move_capital"] is False
+          PY
+
+      - name: Verify acceptance contract
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          acceptance = json.loads(
+              Path("docs/testing/EVE_Q_GATE1_SOURCE_REVIEW_ACCEPTANCE_v0_1.json")
+              .read_text(encoding="utf-8")
+          )
+          assert all(acceptance["required_acceptance"].values())
+          assert acceptance["network_calls_permitted"] is False
+          assert acceptance["authority"] is False
+          assert acceptance["may_activate_gate_1"] is False
+          assert acceptance["may_generate_live_proposal"] is False
+          assert acceptance["may_execute"] is False
+          assert acceptance["may_move_capital"] is False
+          PY
+
+      - name: Verify non-promotion language
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          text = Path(
+              "docs/telemetry/EVE_Q_GATE1_SOURCE_REVIEW_ARTIFACT_v0_1.md"
+          ).read_text(encoding="utf-8")
+          for phrase in [
+              "ELIGIBLE != Gate 1 activation",
+              "successful verification != source truth",
+              "content address != legal permission",
+              "confidence != authority",
+          ]:
+              assert phrase in text, phrase
+          PY

--- a/docs/telemetry/EVE_Q_GATE1_SOURCE_REVIEW_ARTIFACT_v0_1.md
+++ b/docs/telemetry/EVE_Q_GATE1_SOURCE_REVIEW_ARTIFACT_v0_1.md
@@ -1,0 +1,136 @@
+# EVE_Q++ Gate 1 Source Review Artifact v0.1
+
+## Purpose
+
+A candidate live read-only telemetry source must be reviewed before it may enter the bounded Gate 1 pilot.
+
+```text
+candidate source
+→ source-review candidate document
+→ deterministic validation
+→ observation-eligibility decision
+→ content-addressed review artifact
+→ human review
+```
+
+The artifact approves only **observation eligibility**. It does not activate Gate 1, generate proposals, execute transactions, sign messages, submit orders, or move capital.
+
+## Gate posture
+
+```text
+Gate 0 SIMULATION_ONLY: ACTIVE
+Gate 1 LIVE_READ_ONLY_TELEMETRY: PILOT_ONLY
+Gate 2–6: LOCKED
+```
+
+## Reviewed source surface
+
+The source review records:
+
+- source identity, operator, source kind, and exact endpoint;
+- exact hostname allowlist;
+- `GET` or `HEAD` only;
+- authentication mode and proof that any credential reference is explicitly read-only;
+- documented rate limit and expected response-size cap;
+- expected JSON or plain-text payload class;
+- freshness TTL, outage expectations, and redirect policy;
+- provenance group, upstream provider, source-independence note, and concentration risk;
+- legal/terms disposition;
+- transport residual-risk disposition;
+- rollback and kill-switch compatibility;
+- human reviewer identity and exact producer commit.
+
+No credential value belongs in this artifact. A credential reference is an environment-variable name or external-vault pointer only.
+
+## Deterministic decision
+
+The builder computes one observation-eligibility disposition:
+
+- `ELIGIBLE`: all required controls are reviewed and compatible;
+- `HOLD`: review, transport, rollback, kill-switch, or concentration work remains unresolved;
+- `REJECT`: terms or residual transport risk are explicitly incompatible.
+
+A source marked `ELIGIBLE` still cannot activate Gate 1. It may only proceed to the separately bounded campaign in issue #76 after explicit human review.
+
+## Credential boundary
+
+Allowed authentication modes:
+
+```text
+NONE
+READ_ONLY_CREDENTIAL
+```
+
+A read-only credential reference must visibly contain `READ_ONLY` or `READONLY`. Wallet seeds, mnemonics, private keys, signing keys, trading secrets, order secrets, and wallet references fail closed.
+
+## Build
+
+Start from the non-live template:
+
+```bash
+cp \
+  examples/telemetry/source_review_candidate_template_v0_1.json \
+  /tmp/gate1-source-review-candidate.json
+```
+
+Build a deterministic artifact with an explicit timestamp and producer commit:
+
+```bash
+python -m eve_q.gate1_source_review build \
+  --candidate /tmp/gate1-source-review-candidate.json \
+  --producer-commit "$(git rev-parse HEAD)" \
+  --created-at 2026-07-12T01:00:00Z \
+  --output /tmp/gate1-source-review-artifact.json
+```
+
+Verify offline:
+
+```bash
+python -m eve_q.gate1_source_review verify \
+  --artifact /tmp/gate1-source-review-artifact.json
+```
+
+The supplied template must build to `HOLD`. It is deliberately not a reviewed live source.
+
+## Content address
+
+`artifact_id` is SHA-256 over canonical UTF-8 JSON with sorted keys and compact separators after removing the `artifact_id` field itself.
+
+Changing the endpoint, host allowlist, provenance assessment, legal review, risk disposition, reviewer, timestamp, or producer commit changes the artifact identity.
+
+## Relationship to later work
+
+```text
+#77 source-review contract
+→ #78 non-live soak scaffold
+→ #76 reviewed bounded live campaign
+→ #68 Gate 1 evidence decision
+```
+
+No earlier stage implies the next.
+
+## Boundary
+
+```text
+source review artifact != live capture
+ELIGIBLE != Gate 1 activation
+successful verification != source truth
+content address != legal permission
+confidence != authority
+```
+
+Every artifact carries:
+
+```json
+{
+  "artifact_is_command": false,
+  "authority": false,
+  "human_promotion_required": true,
+  "may_activate_gate_1": false,
+  "may_generate_live_proposal": false,
+  "may_execute": false,
+  "may_move_capital": false
+}
+```
+
+> Observation eligibility is a passport check, not permission to fly the aircraft.

--- a/docs/testing/EVE_Q_GATE1_SOURCE_REVIEW_ACCEPTANCE_v0_1.json
+++ b/docs/testing/EVE_Q_GATE1_SOURCE_REVIEW_ACCEPTANCE_v0_1.json
@@ -1,0 +1,32 @@
+{
+  "artifact_is_command": false,
+  "artifact_type": "Gate1SourceReviewAcceptance",
+  "authority": false,
+  "contract_version": "eve_q_gate1_source_review_v0.1",
+  "gate_posture": {
+    "gate_0": "ACTIVE",
+    "gate_1": "PILOT_ONLY",
+    "gate_2_through_6": "LOCKED"
+  },
+  "human_promotion_required": true,
+  "may_activate_gate_1": false,
+  "may_execute": false,
+  "may_generate_live_proposal": false,
+  "may_move_capital": false,
+  "network_calls_permitted": false,
+  "required_acceptance": {
+    "credential_values_absent": true,
+    "deterministic_artifact_identity": true,
+    "exact_host_allowlist": true,
+    "explicit_observation_eligibility": true,
+    "https_get_or_head_only": true,
+    "legal_terms_disposition_recorded": true,
+    "offline_verification": true,
+    "provenance_and_concentration_reviewed": true,
+    "rollback_and_kill_switch_compatibility_recorded": true,
+    "strict_schema_unknown_properties_rejected": true,
+    "template_remains_hold": true,
+    "transport_residual_risk_recorded": true,
+    "zero_authority_escalation": true
+  }
+}

--- a/eve_q/gate1_source_review.py
+++ b/eve_q/gate1_source_review.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import urllib.parse
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+CONTRACT_VERSION = "eve_q_gate1_source_review_v0.1"
+ARTIFACT_TYPE = "Gate1SourceReviewArtifact"
+ALLOWED_METHODS = frozenset({"GET", "HEAD"})
+ALLOWED_SOURCE_KINDS = frozenset(
+    {
+        "market_snapshot",
+        "onchain_snapshot",
+        "policy_snapshot",
+        "impact_snapshot",
+    }
+)
+ALLOWED_CONTENT_TYPES = frozenset({"application/json", "text/plain"})
+MAX_TTL_SECONDS = 86_400
+MAX_RESPONSE_BYTES = 10_485_760
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+CID_RE = re.compile(r"^(?:Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{20,})$")
+READ_ONLY_MARKERS = ("READ_ONLY", "READONLY")
+FORBIDDEN_CREDENTIAL_MARKERS = (
+    "PRIVATE_KEY",
+    "SEED_PHRASE",
+    "MNEMONIC",
+    "SIGNING_KEY",
+    "TRADING_SECRET",
+    "ORDER_SECRET",
+    "WALLET",
+)
+
+
+class Gate1SourceReviewError(ValueError):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+    def as_dict(self) -> dict[str, str]:
+        return {"code": self.code, "message": self.message}
+
+
+def canonical_json_bytes(document: Any) -> bytes:
+    return json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def sha256_hex(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def artifact_payload(document: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(document)
+    payload.pop("artifact_id", None)
+    return payload
+
+
+def compute_artifact_id(document: Mapping[str, Any]) -> str:
+    return sha256_hex(canonical_json_bytes(artifact_payload(document)))
+
+
+def refresh_artifact_id(document: Mapping[str, Any]) -> dict[str, Any]:
+    refreshed = dict(document)
+    refreshed["artifact_id"] = compute_artifact_id(refreshed)
+    return refreshed
+
+
+def normalize_created_at(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise Gate1SourceReviewError(
+            "invalid_created_at",
+            "created_at must be a valid RFC3339 timestamp",
+        ) from exc
+    if parsed.tzinfo is None:
+        raise Gate1SourceReviewError(
+            "invalid_created_at",
+            "created_at must include a UTC offset",
+        )
+    return parsed.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def normalize_host(value: str) -> str:
+    return value.strip().rstrip(".").lower()
+
+
+def _require_text(value: Any, field: str) -> str:
+    text = str(value).strip()
+    if not text:
+        raise Gate1SourceReviewError("missing_field", f"{field} is required")
+    return text
+
+
+def _validate_commit(value: str) -> None:
+    if not COMMIT_RE.fullmatch(value):
+        raise Gate1SourceReviewError(
+            "invalid_producer_commit",
+            "producer_commit must be exactly 40 lowercase hexadecimal characters",
+        )
+
+
+def _validate_source(source: Mapping[str, Any]) -> dict[str, Any]:
+    source_id = _require_text(source.get("source_id"), "source.source_id")
+    source_name = _require_text(source.get("source_name"), "source.source_name")
+    operator = _require_text(source.get("operator"), "source.operator")
+    source_kind = _require_text(source.get("source_kind"), "source.source_kind")
+    if source_kind not in ALLOWED_SOURCE_KINDS:
+        raise Gate1SourceReviewError(
+            "unsupported_source_kind",
+            f"unsupported source_kind: {source_kind}",
+        )
+
+    endpoint_uri = _require_text(source.get("endpoint_uri"), "source.endpoint_uri")
+    parsed = urllib.parse.urlparse(endpoint_uri)
+    if parsed.scheme.lower() != "https":
+        raise Gate1SourceReviewError(
+            "scheme_not_https",
+            "source endpoint must use HTTPS",
+        )
+    if parsed.username or parsed.password:
+        raise Gate1SourceReviewError(
+            "embedded_credentials_rejected",
+            "credentials may not be embedded in the endpoint URI",
+        )
+    if not parsed.hostname:
+        raise Gate1SourceReviewError("missing_host", "source endpoint has no host")
+    if parsed.port not in (None, 443):
+        raise Gate1SourceReviewError(
+            "non_standard_port_rejected",
+            "Gate 1 source review permits HTTPS port 443 only",
+        )
+
+    allowed_hosts_raw = source.get("allowed_hosts")
+    if not isinstance(allowed_hosts_raw, list) or not allowed_hosts_raw:
+        raise Gate1SourceReviewError(
+            "empty_allowlist",
+            "source.allowed_hosts must contain at least one exact host",
+        )
+    allowed_hosts = sorted({normalize_host(str(item)) for item in allowed_hosts_raw})
+    if any(not host or "*" in host or "/" in host for host in allowed_hosts):
+        raise Gate1SourceReviewError(
+            "invalid_allowlist_host",
+            "allowed hosts must be exact hostnames without wildcards or paths",
+        )
+    endpoint_host = normalize_host(parsed.hostname)
+    if endpoint_host not in allowed_hosts:
+        raise Gate1SourceReviewError(
+            "host_not_allowlisted",
+            f"endpoint host is not exactly allowlisted: {endpoint_host}",
+        )
+
+    method = _require_text(source.get("method"), "source.method").upper()
+    if method not in ALLOWED_METHODS:
+        raise Gate1SourceReviewError(
+            "write_method_rejected",
+            f"method is not read-only: {method}",
+        )
+
+    auth_mode = _require_text(source.get("auth_mode"), "source.auth_mode")
+    if auth_mode not in {"NONE", "READ_ONLY_CREDENTIAL"}:
+        raise Gate1SourceReviewError(
+            "invalid_auth_mode",
+            "auth_mode must be NONE or READ_ONLY_CREDENTIAL",
+        )
+
+    credential_reference_name = source.get("credential_reference_name")
+    credential_proof_note = source.get("credential_proof_note")
+    if auth_mode == "NONE":
+        if credential_reference_name is not None or credential_proof_note is not None:
+            raise Gate1SourceReviewError(
+                "unexpected_credential_metadata",
+                "credential metadata must be null when auth_mode is NONE",
+            )
+    else:
+        credential_reference_name = _require_text(
+            credential_reference_name,
+            "source.credential_reference_name",
+        ).upper()
+        credential_proof_note = _require_text(
+            credential_proof_note,
+            "source.credential_proof_note",
+        )
+        if not any(marker in credential_reference_name for marker in READ_ONLY_MARKERS):
+            raise Gate1SourceReviewError(
+                "credential_not_demonstrably_read_only",
+                "credential reference name must explicitly declare READ_ONLY or READONLY",
+            )
+        if any(marker in credential_reference_name for marker in FORBIDDEN_CREDENTIAL_MARKERS):
+            raise Gate1SourceReviewError(
+                "write_capable_credential_reference_rejected",
+                "credential reference name contains a prohibited write-capable marker",
+            )
+
+    content_types_raw = source.get("expected_content_types")
+    if not isinstance(content_types_raw, list) or not content_types_raw:
+        raise Gate1SourceReviewError(
+            "missing_content_types",
+            "expected_content_types must be a non-empty list",
+        )
+    content_types = sorted({str(item).strip().lower() for item in content_types_raw})
+    unsupported = sorted(set(content_types) - ALLOWED_CONTENT_TYPES)
+    if unsupported:
+        raise Gate1SourceReviewError(
+            "unsupported_content_type",
+            "unsupported expected content types: " + ", ".join(unsupported),
+        )
+
+    freshness_ttl_seconds = int(source.get("freshness_ttl_seconds", 0))
+    if not 1 <= freshness_ttl_seconds <= MAX_TTL_SECONDS:
+        raise Gate1SourceReviewError(
+            "invalid_freshness_ttl",
+            f"freshness_ttl_seconds must be between 1 and {MAX_TTL_SECONDS}",
+        )
+
+    expected_max_response_bytes = int(source.get("expected_max_response_bytes", 0))
+    if not 1 <= expected_max_response_bytes <= MAX_RESPONSE_BYTES:
+        raise Gate1SourceReviewError(
+            "invalid_response_cap",
+            f"expected_max_response_bytes must be between 1 and {MAX_RESPONSE_BYTES}",
+        )
+
+    rate_limit = source.get("documented_rate_limit")
+    if not isinstance(rate_limit, Mapping):
+        raise Gate1SourceReviewError(
+            "missing_rate_limit",
+            "documented_rate_limit must be an object",
+        )
+    requests = int(rate_limit.get("requests", 0))
+    per_seconds = int(rate_limit.get("per_seconds", 0))
+    if requests < 1 or per_seconds < 1:
+        raise Gate1SourceReviewError(
+            "invalid_rate_limit",
+            "documented rate limit values must be positive integers",
+        )
+
+    redirect_policy = _require_text(
+        source.get("redirect_policy"),
+        "source.redirect_policy",
+    )
+    if redirect_policy not in {"NO_REDIRECTS", "EXACT_ALLOWLIST_ONLY"}:
+        raise Gate1SourceReviewError(
+            "invalid_redirect_policy",
+            "redirect_policy must be NO_REDIRECTS or EXACT_ALLOWLIST_ONLY",
+        )
+
+    return {
+        "source_id": source_id,
+        "source_name": source_name,
+        "operator": operator,
+        "source_kind": source_kind,
+        "endpoint_uri": endpoint_uri,
+        "allowed_hosts": allowed_hosts,
+        "method": method,
+        "auth_mode": auth_mode,
+        "credential_reference_name": credential_reference_name,
+        "credential_proof_note": credential_proof_note,
+        "documented_rate_limit": {
+            "requests": requests,
+            "per_seconds": per_seconds,
+        },
+        "expected_content_types": content_types,
+        "expected_max_response_bytes": expected_max_response_bytes,
+        "freshness_ttl_seconds": freshness_ttl_seconds,
+        "outage_expectation": _require_text(
+            source.get("outage_expectation"),
+            "source.outage_expectation",
+        ),
+        "redirect_policy": redirect_policy,
+    }
+
+
+def _validate_provenance(provenance: Mapping[str, Any]) -> dict[str, Any]:
+    concentration = _require_text(
+        provenance.get("upstream_concentration"),
+        "provenance.upstream_concentration",
+    )
+    if concentration not in {"LOW", "MEDIUM", "HIGH", "UNKNOWN"}:
+        raise Gate1SourceReviewError(
+            "invalid_upstream_concentration",
+            "upstream_concentration must be LOW, MEDIUM, HIGH, or UNKNOWN",
+        )
+    return {
+        "provenance_group": _require_text(
+            provenance.get("provenance_group"),
+            "provenance.provenance_group",
+        ),
+        "upstream_provider": _require_text(
+            provenance.get("upstream_provider"),
+            "provenance.upstream_provider",
+        ),
+        "upstream_concentration": concentration,
+        "source_independence_note": _require_text(
+            provenance.get("source_independence_note"),
+            "provenance.source_independence_note",
+        ),
+        "concentration_mitigation": str(
+            provenance.get("concentration_mitigation", "")
+        ).strip(),
+    }
+
+
+def _build_review(review: Mapping[str, Any], provenance: Mapping[str, Any]) -> dict[str, Any]:
+    terms_disposition = _require_text(
+        review.get("terms_disposition"),
+        "review.terms_disposition",
+    )
+    if terms_disposition not in {
+        "REVIEWED_COMPATIBLE",
+        "REVIEWED_RESTRICTED",
+        "NOT_REVIEWED",
+    }:
+        raise Gate1SourceReviewError(
+            "invalid_terms_disposition",
+            "terms_disposition is not recognized",
+        )
+
+    transport_risk = _require_text(
+        review.get("transport_residual_risk"),
+        "review.transport_residual_risk",
+    )
+    if transport_risk not in {
+        "ACCEPTED_WITH_CONTROLS",
+        "REJECTED",
+        "UNRESOLVED",
+    }:
+        raise Gate1SourceReviewError(
+            "invalid_transport_risk",
+            "transport_residual_risk is not recognized",
+        )
+
+    rollback_compatible = bool(review.get("rollback_compatible"))
+    kill_switch_compatible = bool(review.get("kill_switch_compatible"))
+    legal_terms_note = _require_text(
+        review.get("legal_terms_note"),
+        "review.legal_terms_note",
+    )
+    review_notes_raw = review.get("review_notes", [])
+    if not isinstance(review_notes_raw, list):
+        raise Gate1SourceReviewError(
+            "invalid_review_notes",
+            "review_notes must be a list",
+        )
+    review_notes = sorted({str(item).strip() for item in review_notes_raw if str(item).strip()})
+
+    reasons: list[str] = []
+    decision = "ELIGIBLE"
+
+    if terms_disposition == "REVIEWED_RESTRICTED":
+        decision = "REJECT"
+        reasons.append("source terms are incompatible with the bounded pilot")
+    elif transport_risk == "REJECTED":
+        decision = "REJECT"
+        reasons.append("transport residual risk was rejected")
+    else:
+        if terms_disposition == "NOT_REVIEWED":
+            reasons.append("source terms have not been reviewed")
+        if transport_risk == "UNRESOLVED":
+            reasons.append("transport residual risk remains unresolved")
+        if not rollback_compatible:
+            reasons.append("source is not yet proven rollback-compatible")
+        if not kill_switch_compatible:
+            reasons.append("source is not yet proven kill-switch-compatible")
+        if (
+            provenance["upstream_concentration"] == "HIGH"
+            and not provenance["concentration_mitigation"]
+        ):
+            reasons.append("high upstream concentration lacks a mitigation note")
+        if reasons:
+            decision = "HOLD"
+
+    if not reasons:
+        reasons.append("all observation-eligibility controls passed review")
+
+    return {
+        "terms_disposition": terms_disposition,
+        "legal_terms_note": legal_terms_note,
+        "transport_residual_risk": transport_risk,
+        "rollback_compatible": rollback_compatible,
+        "kill_switch_compatible": kill_switch_compatible,
+        "review_notes": review_notes,
+        "observation_eligibility": decision,
+        "decision_reasons": reasons,
+    }
+
+
+def build_source_review_artifact(
+    candidate: Mapping[str, Any],
+    *,
+    producer_commit: str,
+    created_at: str,
+) -> dict[str, Any]:
+    _validate_commit(producer_commit)
+    reviewer_id = _require_text(candidate.get("reviewer_id"), "reviewer_id")
+    source_raw = candidate.get("source")
+    provenance_raw = candidate.get("provenance")
+    review_raw = candidate.get("review")
+    if not isinstance(source_raw, Mapping):
+        raise Gate1SourceReviewError("missing_source", "source must be an object")
+    if not isinstance(provenance_raw, Mapping):
+        raise Gate1SourceReviewError(
+            "missing_provenance",
+            "provenance must be an object",
+        )
+    if not isinstance(review_raw, Mapping):
+        raise Gate1SourceReviewError("missing_review", "review must be an object")
+
+    source = _validate_source(source_raw)
+    provenance = _validate_provenance(provenance_raw)
+    review = _build_review(review_raw, provenance)
+
+    document: dict[str, Any] = {
+        "artifact_type": ARTIFACT_TYPE,
+        "contract_version": CONTRACT_VERSION,
+        "artifact_id": "",
+        "created_at": normalize_created_at(created_at),
+        "reviewer_id": reviewer_id,
+        "source": source,
+        "provenance": provenance,
+        "review": review,
+        "producer_repository": "ArchitectofAthena/CodexTradingEngine",
+        "producer_commit": producer_commit,
+        "gate_posture": {
+            "gate_0": "ACTIVE",
+            "gate_1": "PILOT_ONLY",
+            "gate_2_through_6": "LOCKED",
+        },
+        "artifact_is_command": False,
+        "authority": False,
+        "human_promotion_required": True,
+        "may_activate_gate_1": False,
+        "may_generate_live_proposal": False,
+        "may_execute": False,
+        "may_move_capital": False,
+    }
+    document["artifact_id"] = compute_artifact_id(document)
+    return document
+
+
+def validate_source_review_artifact(document: Mapping[str, Any]) -> list[str]:
+    findings: list[str] = []
+    if document.get("artifact_type") != ARTIFACT_TYPE:
+        findings.append("artifact_type is not Gate1SourceReviewArtifact")
+    if document.get("contract_version") != CONTRACT_VERSION:
+        findings.append("contract_version is not eve_q_gate1_source_review_v0.1")
+    if document.get("artifact_id") != compute_artifact_id(document):
+        findings.append("artifact_id does not match canonical payload hash")
+    if not HASH_RE.fullmatch(str(document.get("artifact_id", ""))):
+        findings.append("artifact_id must be a lowercase SHA-256 hex digest")
+    try:
+        _validate_commit(str(document.get("producer_commit", "")))
+    except Gate1SourceReviewError as exc:
+        findings.append(exc.message)
+    try:
+        normalize_created_at(str(document.get("created_at", "")))
+    except Gate1SourceReviewError as exc:
+        findings.append(exc.message)
+
+    for field, expected in {
+        "artifact_is_command": False,
+        "authority": False,
+        "human_promotion_required": True,
+        "may_activate_gate_1": False,
+        "may_generate_live_proposal": False,
+        "may_execute": False,
+        "may_move_capital": False,
+    }.items():
+        if document.get(field) is not expected:
+            findings.append(f"{field} must be {str(expected).lower()}")
+
+    gate_posture = document.get("gate_posture")
+    if gate_posture != {
+        "gate_0": "ACTIVE",
+        "gate_1": "PILOT_ONLY",
+        "gate_2_through_6": "LOCKED",
+    }:
+        findings.append("gate_posture must preserve Gate 0 active, Gate 1 pilot-only, and Gate 2-6 locked")
+
+    try:
+        source = _validate_source(document.get("source", {}))
+        provenance = _validate_provenance(document.get("provenance", {}))
+        declared_review = document.get("review", {})
+        rebuilt_review = _build_review(declared_review, provenance)
+        if declared_review.get("observation_eligibility") != rebuilt_review["observation_eligibility"]:
+            findings.append("observation_eligibility does not match review controls")
+        if declared_review.get("decision_reasons") != rebuilt_review["decision_reasons"]:
+            findings.append("decision_reasons do not match review controls")
+        if source["method"] not in ALLOWED_METHODS:
+            findings.append("source method is not observation-only")
+    except Gate1SourceReviewError as exc:
+        findings.append(exc.message)
+
+    return sorted(set(findings))
+
+
+def write_artifact(document: Mapping[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build or verify a bounded Gate 1 source-review artifact."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser("build")
+    build_parser.add_argument("--candidate", type=Path, required=True)
+    build_parser.add_argument("--producer-commit", required=True)
+    build_parser.add_argument("--created-at", required=True)
+    build_parser.add_argument("--output", type=Path, required=True)
+
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("--artifact", type=Path, required=True)
+
+    args = parser.parse_args()
+    if args.command == "build":
+        artifact = build_source_review_artifact(
+            _load_json(args.candidate),
+            producer_commit=args.producer_commit,
+            created_at=args.created_at,
+        )
+        write_artifact(artifact, args.output)
+        print(json.dumps(artifact, indent=2, sort_keys=True))
+        return 0
+
+    artifact = _load_json(args.artifact)
+    findings = validate_source_review_artifact(artifact)
+    print(json.dumps({"valid": not findings, "findings": findings}, indent=2, sort_keys=True))
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/telemetry/source_review_candidate_template_v0_1.json
+++ b/examples/telemetry/source_review_candidate_template_v0_1.json
@@ -1,0 +1,45 @@
+{
+  "provenance": {
+    "concentration_mitigation": "",
+    "provenance_group": "UNREVIEWED_TEMPLATE",
+    "source_independence_note": "Template only. No source-independence claim has been reviewed.",
+    "upstream_concentration": "UNKNOWN",
+    "upstream_provider": "UNREVIEWED_TEMPLATE"
+  },
+  "review": {
+    "kill_switch_compatible": false,
+    "legal_terms_note": "Terms have not been reviewed. This template is not observation-eligible.",
+    "review_notes": [
+      "Replace all template fields only after human source review."
+    ],
+    "rollback_compatible": false,
+    "terms_disposition": "NOT_REVIEWED",
+    "transport_residual_risk": "UNRESOLVED"
+  },
+  "reviewer_id": "UNASSIGNED",
+  "source": {
+    "allowed_hosts": [
+      "data.example.test"
+    ],
+    "auth_mode": "NONE",
+    "credential_proof_note": null,
+    "credential_reference_name": null,
+    "documented_rate_limit": {
+      "per_seconds": 60,
+      "requests": 1
+    },
+    "endpoint_uri": "https://data.example.test/v1/observation",
+    "expected_content_types": [
+      "application/json"
+    ],
+    "expected_max_response_bytes": 1048576,
+    "freshness_ttl_seconds": 300,
+    "method": "GET",
+    "operator": "UNREVIEWED_TEMPLATE",
+    "outage_expectation": "Unknown until source documentation and observed behavior are reviewed.",
+    "redirect_policy": "EXACT_ALLOWLIST_ONLY",
+    "source_id": "unreviewed-template-source",
+    "source_kind": "market_snapshot",
+    "source_name": "Unreviewed Template Source"
+  }
+}

--- a/schemas/gate1_source_review_artifact_v0_1.schema.json
+++ b/schemas/gate1_source_review_artifact_v0_1.schema.json
@@ -1,0 +1,327 @@
+{
+  "$id": "https://spiralbloom.local/schemas/gate1_source_review_artifact_v0_1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "artifact_type": {
+      "const": "Gate1SourceReviewArtifact"
+    },
+    "contract_version": {
+      "const": "eve_q_gate1_source_review_v0.1"
+    },
+    "artifact_id": {
+      "pattern": "^[0-9a-f]{64}$",
+      "type": "string"
+    },
+    "created_at": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "reviewer_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "source": {
+      "additionalProperties": false,
+      "properties": {
+        "source_id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "source_name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "operator": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "source_kind": {
+          "enum": [
+            "market_snapshot",
+            "onchain_snapshot",
+            "policy_snapshot",
+            "impact_snapshot"
+          ]
+        },
+        "endpoint_uri": {
+          "format": "uri",
+          "pattern": "^https://",
+          "type": "string"
+        },
+        "allowed_hosts": {
+          "items": {
+            "minLength": 1,
+            "pattern": "^[^*/]+$",
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "method": {
+          "enum": [
+            "GET",
+            "HEAD"
+          ]
+        },
+        "auth_mode": {
+          "enum": [
+            "NONE",
+            "READ_ONLY_CREDENTIAL"
+          ]
+        },
+        "credential_reference_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "credential_proof_note": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "documented_rate_limit": {
+          "additionalProperties": false,
+          "properties": {
+            "requests": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "per_seconds": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "requests",
+            "per_seconds"
+          ],
+          "type": "object"
+        },
+        "expected_content_types": {
+          "items": {
+            "enum": [
+              "application/json",
+              "text/plain"
+            ]
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        },
+        "expected_max_response_bytes": {
+          "maximum": 10485760,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "freshness_ttl_seconds": {
+          "maximum": 86400,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "outage_expectation": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "redirect_policy": {
+          "enum": [
+            "NO_REDIRECTS",
+            "EXACT_ALLOWLIST_ONLY"
+          ]
+        }
+      },
+      "required": [
+        "source_id",
+        "source_name",
+        "operator",
+        "source_kind",
+        "endpoint_uri",
+        "allowed_hosts",
+        "method",
+        "auth_mode",
+        "credential_reference_name",
+        "credential_proof_note",
+        "documented_rate_limit",
+        "expected_content_types",
+        "expected_max_response_bytes",
+        "freshness_ttl_seconds",
+        "outage_expectation",
+        "redirect_policy"
+      ],
+      "type": "object"
+    },
+    "provenance": {
+      "additionalProperties": false,
+      "properties": {
+        "provenance_group": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "upstream_provider": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "upstream_concentration": {
+          "enum": [
+            "LOW",
+            "MEDIUM",
+            "HIGH",
+            "UNKNOWN"
+          ]
+        },
+        "source_independence_note": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "concentration_mitigation": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "provenance_group",
+        "upstream_provider",
+        "upstream_concentration",
+        "source_independence_note",
+        "concentration_mitigation"
+      ],
+      "type": "object"
+    },
+    "review": {
+      "additionalProperties": false,
+      "properties": {
+        "terms_disposition": {
+          "enum": [
+            "REVIEWED_COMPATIBLE",
+            "REVIEWED_RESTRICTED",
+            "NOT_REVIEWED"
+          ]
+        },
+        "legal_terms_note": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "transport_residual_risk": {
+          "enum": [
+            "ACCEPTED_WITH_CONTROLS",
+            "REJECTED",
+            "UNRESOLVED"
+          ]
+        },
+        "rollback_compatible": {
+          "type": "boolean"
+        },
+        "kill_switch_compatible": {
+          "type": "boolean"
+        },
+        "review_notes": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "array",
+          "uniqueItems": true
+        },
+        "observation_eligibility": {
+          "enum": [
+            "ELIGIBLE",
+            "HOLD",
+            "REJECT"
+          ]
+        },
+        "decision_reasons": {
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 1,
+          "type": "array",
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "terms_disposition",
+        "legal_terms_note",
+        "transport_residual_risk",
+        "rollback_compatible",
+        "kill_switch_compatible",
+        "review_notes",
+        "observation_eligibility",
+        "decision_reasons"
+      ],
+      "type": "object"
+    },
+    "producer_repository": {
+      "const": "ArchitectofAthena/CodexTradingEngine"
+    },
+    "producer_commit": {
+      "pattern": "^[0-9a-f]{40}$",
+      "type": "string"
+    },
+    "gate_posture": {
+      "additionalProperties": false,
+      "properties": {
+        "gate_0": {
+          "const": "ACTIVE"
+        },
+        "gate_1": {
+          "const": "PILOT_ONLY"
+        },
+        "gate_2_through_6": {
+          "const": "LOCKED"
+        }
+      },
+      "required": [
+        "gate_0",
+        "gate_1",
+        "gate_2_through_6"
+      ],
+      "type": "object"
+    },
+    "artifact_is_command": {
+      "const": false
+    },
+    "authority": {
+      "const": false
+    },
+    "human_promotion_required": {
+      "const": true
+    },
+    "may_activate_gate_1": {
+      "const": false
+    },
+    "may_generate_live_proposal": {
+      "const": false
+    },
+    "may_execute": {
+      "const": false
+    },
+    "may_move_capital": {
+      "const": false
+    }
+  },
+  "required": [
+    "artifact_type",
+    "contract_version",
+    "artifact_id",
+    "created_at",
+    "reviewer_id",
+    "source",
+    "provenance",
+    "review",
+    "producer_repository",
+    "producer_commit",
+    "gate_posture",
+    "artifact_is_command",
+    "authority",
+    "human_promotion_required",
+    "may_activate_gate_1",
+    "may_generate_live_proposal",
+    "may_execute",
+    "may_move_capital"
+  ],
+  "title": "EVE_Q++ Gate1SourceReviewArtifact v0.1",
+  "type": "object"
+}

--- a/tests/test_gate1_source_review_artifact_v0_1.py
+++ b/tests/test_gate1_source_review_artifact_v0_1.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator, FormatChecker
+
+from eve_q.gate1_source_review import (
+    Gate1SourceReviewError,
+    build_source_review_artifact,
+    refresh_artifact_id,
+    validate_source_review_artifact,
+)
+
+SCHEMA_PATH = Path("schemas/gate1_source_review_artifact_v0_1.schema.json")
+TEMPLATE_PATH = Path("examples/telemetry/source_review_candidate_template_v0_1.json")
+PRODUCER_COMMIT = "a" * 40
+CREATED_AT = "2026-07-12T01:00:00Z"
+
+
+def candidate(**overrides):
+    document = {
+        "reviewer_id": "human:architect",
+        "source": {
+            "source_id": "reviewed-public-market-source",
+            "source_name": "Reviewed Public Market Source",
+            "operator": "Example Data Operator",
+            "source_kind": "market_snapshot",
+            "endpoint_uri": "https://data.example.test/v1/market",
+            "allowed_hosts": ["data.example.test"],
+            "method": "GET",
+            "auth_mode": "NONE",
+            "credential_reference_name": None,
+            "credential_proof_note": None,
+            "documented_rate_limit": {
+                "requests": 30,
+                "per_seconds": 60,
+            },
+            "expected_content_types": ["application/json"],
+            "expected_max_response_bytes": 1_048_576,
+            "freshness_ttl_seconds": 300,
+            "outage_expectation": "Transient outages fail closed and return the pilot to Gate 0.",
+            "redirect_policy": "EXACT_ALLOWLIST_ONLY",
+        },
+        "provenance": {
+            "provenance_group": "example-independent-market-data",
+            "upstream_provider": "Example Data Operator",
+            "upstream_concentration": "LOW",
+            "source_independence_note": "Operator documents a direct source rather than a shared aggregator.",
+            "concentration_mitigation": "",
+        },
+        "review": {
+            "terms_disposition": "REVIEWED_COMPATIBLE",
+            "legal_terms_note": "Human reviewer recorded compatibility with bounded read-only research use.",
+            "transport_residual_risk": "ACCEPTED_WITH_CONTROLS",
+            "rollback_compatible": True,
+            "kill_switch_compatible": True,
+            "review_notes": ["No credential required."],
+        },
+    }
+    for key, value in overrides.items():
+        if key in {"source", "provenance", "review"}:
+            document[key].update(value)
+        else:
+            document[key] = value
+    return document
+
+
+def schema_findings(document: dict) -> list:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    return list(
+        Draft202012Validator(
+            schema,
+            format_checker=FormatChecker(),
+        ).iter_errors(document)
+    )
+
+
+def build(document=None):
+    return build_source_review_artifact(
+        document or candidate(),
+        producer_commit=PRODUCER_COMMIT,
+        created_at=CREATED_AT,
+    )
+
+
+def test_eligible_public_source_is_deterministic_schema_valid_and_non_authoritative():
+    first = build()
+    second = build()
+
+    assert first == second
+    assert schema_findings(first) == []
+    assert validate_source_review_artifact(first) == []
+    assert first["review"]["observation_eligibility"] == "ELIGIBLE"
+    assert first["source"]["method"] == "GET"
+    assert first["artifact_is_command"] is False
+    assert first["authority"] is False
+    assert first["may_activate_gate_1"] is False
+    assert first["may_generate_live_proposal"] is False
+    assert first["may_execute"] is False
+    assert first["may_move_capital"] is False
+
+
+def test_template_is_deliberately_hold_and_not_a_committed_live_source():
+    template = json.loads(TEMPLATE_PATH.read_text(encoding="utf-8"))
+    artifact = build_source_review_artifact(
+        template,
+        producer_commit=PRODUCER_COMMIT,
+        created_at=CREATED_AT,
+    )
+
+    assert schema_findings(artifact) == []
+    assert validate_source_review_artifact(artifact) == []
+    assert artifact["review"]["observation_eligibility"] == "HOLD"
+    assert artifact["source"]["endpoint_uri"].endswith("example.test/v1/observation")
+    assert artifact["may_activate_gate_1"] is False
+
+
+def test_http_post_embedded_credentials_and_nonstandard_port_fail_closed():
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(candidate(source={"endpoint_uri": "http://data.example.test/v1/market"}))
+    assert exc_info.value.code == "scheme_not_https"
+
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(candidate(source={"method": "POST"}))
+    assert exc_info.value.code == "write_method_rejected"
+
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(candidate(source={"endpoint_uri": "https://user:pass@data.example.test/v1/market"}))
+    assert exc_info.value.code == "embedded_credentials_rejected"
+
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(candidate(source={"endpoint_uri": "https://data.example.test:8443/v1/market"}))
+    assert exc_info.value.code == "non_standard_port_rejected"
+
+
+def test_host_must_be_exactly_allowlisted_without_wildcards():
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(candidate(source={"allowed_hosts": ["other.example.test"]}))
+    assert exc_info.value.code == "host_not_allowlisted"
+
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(candidate(source={"allowed_hosts": ["*.example.test"]}))
+    assert exc_info.value.code == "invalid_allowlist_host"
+
+
+def test_read_only_credential_requires_explicit_safe_reference_and_proof():
+    reviewed = candidate(
+        source={
+            "auth_mode": "READ_ONLY_CREDENTIAL",
+            "credential_reference_name": "EXAMPLE_READ_ONLY_API_KEY",
+            "credential_proof_note": "Provider account role is documented as read-only and cannot submit orders.",
+        }
+    )
+    artifact = build(reviewed)
+    assert artifact["review"]["observation_eligibility"] == "ELIGIBLE"
+
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(
+            candidate(
+                source={
+                    "auth_mode": "READ_ONLY_CREDENTIAL",
+                    "credential_reference_name": "EXAMPLE_API_KEY",
+                    "credential_proof_note": "No role proof.",
+                }
+            )
+        )
+    assert exc_info.value.code == "credential_not_demonstrably_read_only"
+
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build(
+            candidate(
+                source={
+                    "auth_mode": "READ_ONLY_CREDENTIAL",
+                    "credential_reference_name": "WALLET_READ_ONLY_KEY",
+                    "credential_proof_note": "Unsafe wallet-shaped reference.",
+                }
+            )
+        )
+    assert exc_info.value.code == "write_capable_credential_reference_rejected"
+
+
+def test_unresolved_controls_hold_and_incompatible_terms_or_transport_reject():
+    hold = build(
+        candidate(
+            review={
+                "terms_disposition": "NOT_REVIEWED",
+                "transport_residual_risk": "UNRESOLVED",
+                "rollback_compatible": False,
+                "kill_switch_compatible": False,
+            }
+        )
+    )
+    assert hold["review"]["observation_eligibility"] == "HOLD"
+    assert len(hold["review"]["decision_reasons"]) == 4
+
+    rejected_terms = build(
+        candidate(review={"terms_disposition": "REVIEWED_RESTRICTED"})
+    )
+    assert rejected_terms["review"]["observation_eligibility"] == "REJECT"
+
+    rejected_transport = build(
+        candidate(review={"transport_residual_risk": "REJECTED"})
+    )
+    assert rejected_transport["review"]["observation_eligibility"] == "REJECT"
+
+
+def test_high_concentration_without_mitigation_holds():
+    artifact = build(
+        candidate(
+            provenance={
+                "upstream_concentration": "HIGH",
+                "concentration_mitigation": "",
+            }
+        )
+    )
+    assert artifact["review"]["observation_eligibility"] == "HOLD"
+    assert any("concentration" in item for item in artifact["review"]["decision_reasons"])
+
+
+def test_hash_authority_and_decision_mutation_are_detected():
+    artifact = build()
+    mutated = copy.deepcopy(artifact)
+    mutated["authority"] = True
+    mutated["review"]["observation_eligibility"] = "REJECT"
+
+    findings = validate_source_review_artifact(mutated)
+
+    assert "artifact_id does not match canonical payload hash" in findings
+    assert "authority must be false" in findings
+    assert "observation_eligibility does not match review controls" in findings
+
+
+def test_rehashing_cannot_hide_authority_escalation():
+    artifact = build()
+    artifact["may_generate_live_proposal"] = True
+    artifact = refresh_artifact_id(artifact)
+
+    findings = validate_source_review_artifact(artifact)
+
+    assert "artifact_id does not match canonical payload hash" not in findings
+    assert "may_generate_live_proposal must be false" in findings
+
+
+def test_schema_rejects_unknown_properties_and_gate_promotion():
+    artifact = build()
+    artifact["unexpected"] = "nope"
+    artifact["gate_posture"]["gate_1"] = "ACTIVE"
+
+    findings = schema_findings(artifact)
+
+    assert findings
+    assert any("Additional properties" in finding.message for finding in findings)
+    assert any("PILOT_ONLY" in finding.message for finding in findings)
+
+
+def test_invalid_commit_and_timestamp_fail_closed():
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build_source_review_artifact(
+            candidate(),
+            producer_commit="not-a-commit",
+            created_at=CREATED_AT,
+        )
+    assert exc_info.value.code == "invalid_producer_commit"
+
+    with pytest.raises(Gate1SourceReviewError) as exc_info:
+        build_source_review_artifact(
+            candidate(),
+            producer_commit=PRODUCER_COMMIT,
+            created_at="2026-07-12T01:00:00",
+        )
+    assert exc_info.value.code == "invalid_created_at"


### PR DESCRIPTION
## Summary

Implements the canonical, content-addressed source-review artifact required before any candidate live read-only telemetry source may enter the bounded Gate 1 pilot.

```text
candidate source
→ deterministic source review
→ observation-eligibility decision
→ content-addressed artifact
→ human review
```

### Added

- strict `Gate1SourceReviewArtifact` schema;
- deterministic builder and offline verifier;
- HTTPS `GET`/`HEAD` exact-host validation;
- credential-reference checks with no credential values;
- rate-limit, response-cap, freshness, outage, and redirect review fields;
- provenance, upstream concentration, source-independence, and mitigation review;
- legal/terms and transport residual-risk dispositions;
- deterministic `ELIGIBLE`, `HOLD`, or `REJECT` observation-eligibility decision;
- non-live candidate template that must remain `HOLD`;
- acceptance contract, tests, and Python 3.11/3.13 CI.

## Gate posture

```text
Gate 0 SIMULATION_ONLY: ACTIVE
Gate 1 LIVE_READ_ONLY_TELEMETRY: PILOT_ONLY
Gate 2–6: LOCKED
```

## Boundary

```text
source review artifact != live capture
ELIGIBLE != Gate 1 activation
successful verification != source truth
content address != legal permission
confidence != authority
```

No live source is selected or committed. CI performs no network calls. Every artifact remains non-commanding, non-authoritative, and human-gated.

Closes #77 after local Termux reproduction and human merge.